### PR TITLE
Minor change allowing notices without FR urls

### DIFF
--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -102,7 +102,11 @@
                             <h5 class="final-rule">Final Rule</h5>
                             <ul class="rule-list">
                             {% for notice in version.notices %}
-                                <li><a class="fr-notice external" href="{{notice.fr_url}}" target="_blank">Published {{notice.publication_date|date}}</a></li>
+                                {% if notice.fr_url %}
+                                    <li><a class="fr-notice external" href="{{notice.fr_url}}" target="_blank">Published {{notice.publication_date|date}}</a></li>
+                                {% else %}
+                                    <li>Published {{notice.publication_date|date}}</li>
+                                {% endif %}
                             {% endfor %}
                                 </ul>
                                 <div class="diff-selector group">

--- a/regulations/templates/regulations/diff-chrome.html
+++ b/regulations/templates/regulations/diff-chrome.html
@@ -78,7 +78,11 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
                     <div class="timeline-content-wrap">
                     <ul class="rule-list">
                         {% for notice in version.notices %}
-                            <li><a class="fr-notice external" href="{{notice.fr_url}}" target="_blank">Final Rule &#8211; {{notice.publication_date|date}}</a></li>
+                            {% if notice.fr_url %}
+                                <li><a class="fr-notice external" href="{{notice.fr_url}}" target="_blank">Final Rule &#8211; {{notice.publication_date|date}}</a></li>
+                            {% else %}
+                                <li>Final Rule &#8211; {{notice.publication_date|date}}</li>
+                            {% endif %}
                         {% endfor %}
                     </ul>
                         {% if version.version == left_version %}


### PR DESCRIPTION
Helps resolve https://github.com/18F/regulations-parser/issues/32 by not linking to the FR when no url is present.