### PR TITLE
Don't verify https

### DIFF
--- a/regulations/generator/api_client.py
+++ b/regulations/generator/api_client.py
@@ -24,7 +24,7 @@ class ApiClient:
         no error handling"""
 
         if self.base_url.startswith('http'):
-            r = requests.get(self.base_url + suffix, params=params)
+            r = requests.get(self.base_url + suffix, params=params, verify=False)
             if r.status_code == requests.codes.ok:
                 return r.json()
             elif r.status_code == 404:


### PR DESCRIPTION
As we control both ends of the connection, there's no need to verify that the ssl cert is valid. In fact, it's not on the demo servers.