### PR TITLE
Flexible paragraph markers in display

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-#vim: set fileencoding=utf-8
+# vim: set fileencoding=utf-8
 import re
 
 from itertools import ifilter, ifilterfalse, takewhile
@@ -48,22 +48,15 @@ class HTMLBuilder():
     def list_level(self, parts, node_type):
         """ Return the list level and the list type. """
         if node_type == INTERP:
-            level_type_map = {1: '1', 2: 'i', 3: 'A', 4: '1'}
             prefix_length = parts.index('Interp')+1
         elif node_type == APPENDIX:
-            level_type_map = {1: 'a', 2: '1', 3: 'i', 4: 'A', 5: '1', 6: 'i'}
             prefix_length = 3
         else:
-            level_type_map = {1: 'a', 2: '1', 3: 'i', 4: 'A', 5: '1', 6: 'i'}
             prefix_length = 2
 
         if len(parts) > prefix_length:
-            list_level = len(parts) - prefix_length
-            list_type = level_type_map[list_level]
-
-            return (list_level, list_type)
-        else:
-            return (None, None)
+            return len(parts) - prefix_length
+        # implicit return None
 
     def process_node_title(self, node):
         if 'title' in node:
@@ -82,11 +75,9 @@ class HTMLBuilder():
         node['markup_id'] = "-".join(node['html_label'])
         node['tree_level'] = len(node['label']) - 1
 
-        list_level, list_type = self.list_level(
-            node['label'], node['node_type'])
+        list_level = self.list_level(node['label'], node['node_type'])
 
         node['list_level'] = list_level
-        node['list_type'] = list_type
 
         if len(node['text']):
             inline_elements = self.inline_applier.get_layer_pairs(

--- a/regulations/templates/regulations/appendix.html
+++ b/regulations/templates/regulations/appendix.html
@@ -25,7 +25,9 @@
             {% endif %}
 
             {% if level_one.children %}
-                <ol class="level-{{level_one.children.0.list_level}}" type="{{level_one.children.0.list_type}}">
+                {% with first_child=level_one.children|first %}
+                {% include "regulations/ol-tag.html" %}
+                {% endwith %}
                 {% for node in level_one.children  %}
                     {% include "regulations/tree-with-wrapper.html" %}
                 {% endfor %}

--- a/regulations/templates/regulations/interp-tree.html
+++ b/regulations/templates/regulations/interp-tree.html
@@ -17,7 +17,9 @@
     {% endif %}
 
     {% if interp.par_children %}
-        <ol class="level-1" type="1">
+        {% with first_child=interp.par_children|first %}
+            {% include "regulations/ol-tag.html" %}
+        {% endwith %}
             {% for par_child in interp.par_children %}
                 {% with node=par_child %}
                     {% include "regulations/tree-with-wrapper.html" %}

--- a/regulations/templates/regulations/ol-tag.html
+++ b/regulations/templates/regulations/ol-tag.html
@@ -1,0 +1,20 @@
+{% comment %}
+    A node has children, so we need to generate an <ol>. We also need to
+    account for the marker type of that child (or no type, as the case may
+    be).
+    Expects a `first_child` variable
+{% endcomment %}
+{% with m=first_child.label|last %}
+    {% comment %}
+        Note that there isn't a built-in inclusion check in django, so
+        spelling it out with `or`s.
+    {% endcomment %}
+    {% if m == 'a' or m == 'A' or m == 'i' or m == 'I' or m == '1' %}
+        <ol class="level-{{first_child.list_level}}" type="{{m}}"
+                                                     extra="{{first_child.label}}">
+    {% else %}
+        <ol class="level-{{first_child.list_level}}"
+            {% comment %}TODO: Move into stylesheet{% endcomment %}
+            style="list-style: none;">
+    {% endif %}
+{% endwith %}

--- a/regulations/templates/regulations/regulation_text.html
+++ b/regulations/templates/regulations/regulation_text.html
@@ -11,7 +11,9 @@
         </p>
         {% endif %}
 
-        <ol class="level-1" type="a">
+        {% with first_child=c.children|first %}
+            {% include "regulations/ol-tag.html" %}
+        {% endwith %}
         {% if c.children %}
             {% for node in c.children %}
                 {% include "regulations/tree-with-wrapper.html"  %}

--- a/regulations/templates/regulations/tree.html
+++ b/regulations/templates/regulations/tree.html
@@ -15,8 +15,9 @@
 </p>
 {% endif %}
 {% if node.children %}
-<ol class="level-{{node.children.0.list_level}}" 
-    type="{{node.children.0.list_type}}">
+    {% with first_child=node.children|first %}
+    {% include "regulations/ol-tag.html" %}
+    {% endwith %}
     {% for c in node.children %}
         {%with node=c template_name="regulations/tree-with-wrapper.html" %}
             {% include template_name %}

--- a/regulations/tests/html_builder_test.py
+++ b/regulations/tests/html_builder_test.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 from mock import Mock
 
@@ -64,15 +64,15 @@ class HTMLBuilderTest(TestCase):
         node_type = INTERP
 
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (1, '1'))
+        self.assertEquals(result, 1)
 
         parts.append('j')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (2, 'i'))
+        self.assertEquals(result, 2)
 
         parts.append('B')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (3, 'A'))
+        self.assertEquals(result, 3)
 
     def test_list_level_appendices(self):
         builder = HTMLBuilder(None, None, None)
@@ -81,19 +81,19 @@ class HTMLBuilderTest(TestCase):
         node_type = APPENDIX
 
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (1, 'a'))
+        self.assertEquals(result, 1)
 
         parts.append('2')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (2, '1'))
+        self.assertEquals(result, 2)
 
         parts.append('k')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (3, 'i'))
+        self.assertEquals(result, 3)
 
         parts.append('B')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (4, 'A'))
+        self.assertEquals(result, 4)
 
     def test_list_level_regulations(self):
         builder = HTMLBuilder(None, None, None)
@@ -102,19 +102,19 @@ class HTMLBuilderTest(TestCase):
         node_type = REGTEXT
 
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (1, 'a'))
+        self.assertEquals(result, 1)
 
         parts.append('2')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (2, '1'))
+        self.assertEquals(result, 2)
 
         parts.append('k')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (3, 'i'))
+        self.assertEquals(result, 3)
 
         parts.append('B')
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (4, 'A'))
+        self.assertEquals(result, 4)
 
     def test_list_level_regulations_no_level(self):
         builder = HTMLBuilder(None, None, None)
@@ -123,7 +123,7 @@ class HTMLBuilderTest(TestCase):
         node_type = REGTEXT
 
         result = builder.list_level(parts, node_type)
-        self.assertEquals(result, (None, None))
+        self.assertEquals(result, None)
 
     def test_interp_node_with_citations(self):
         inline, p, sr = Mock(), Mock(), Mock()


### PR DESCRIPTION
Previously, the UI was enforcing a specific relationship between node depth and marker type. This removes that restriction (looking instead at the first child). If the first child's marker type is not understood, no marker is displayed.

There's an inline style here, due to not having the frontend build process fully working. We can fix once we pull in the CFPB code.

When no markers are present, looks like:
<img width="636" alt="screen shot 2015-09-04 at 10 18 39 am" src="https://cloud.githubusercontent.com/assets/326918/9685771/5a2630c2-52ee-11e5-8c72-753c1b82792a.png">
<img width="599" alt="screen shot 2015-09-04 at 10 18 18 am" src="https://cloud.githubusercontent.com/assets/326918/9685775/617ae0fc-52ee-11e5-8186-be23772e2a33.png">
