### PR TITLE
Fixups for search results

### DIFF
--- a/regulations/generator/node_types.py
+++ b/regulations/generator/node_types.py
@@ -6,6 +6,7 @@ APPENDIX = u'appendix'
 INTERP = u'interp'
 REGTEXT = u'regtext'
 SUBPART = u'subpart'
+SUBJGRP = u'subjgrp'
 EMPTYPART = u'emptypart'
 
 
@@ -31,6 +32,8 @@ def type_from_label(label):
         return EMPTYPART
     if 'Subpart' in label:  # but not the final segment
         return SUBPART
+    if 'Subjgrp' in label:
+        return SUBJGRP
     if len(label) > 1 and label[1][:1].isalpha():
         return APPENDIX
     return REGTEXT

--- a/regulations/tests/node_types_tests.py
+++ b/regulations/tests/node_types_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 
 from regulations.generator.node_types import *
@@ -39,6 +39,9 @@ class NodeTypesTest(TestCase):
         self.assertEqual('2323.4', label_to_text(['2323', '4']))
         self.assertEqual('2323.5(r)(3)',
                          label_to_text(['2323', '5', 'r', '3']))
+        self.assertEqual('23.5(r)(3)(i)',
+                         label_to_text(['23', '5', 'r', '3', 'i', 'p12', 'A']))
+        self.assertEqual('23.5', label_to_text(['23', '5', 'p1', 'a']))
         self.assertEqual('4', label_to_text(['2323', '4'], False))
         self.assertEqual('5(r)(3)',
                          label_to_text(['2323', '5', 'r', '3'], False))


### PR DESCRIPTION
* Removed markerless paragraphs from the displayed label
* Removes subparts/subject groups from the search results (as we don't display whole subparts/groups in the UI)

Old:
<img width="582" alt="screen shot 2015-09-10 at 1 26 29 pm" src="https://cloud.githubusercontent.com/assets/326918/9795664/e78af65c-57bf-11e5-85ce-7483b6f69537.png">

New:
<img width="578" alt="screen shot 2015-09-10 at 1 27 58 pm" src="https://cloud.githubusercontent.com/assets/326918/9795670/ed62f0ca-57bf-11e5-8620-8bca9de107ad.png">

