### PR TITLE
Fixes for the header

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "backbone-query-parameters": "^0.4.0",
     "jquery": "1.11.0",
     "jquery-scrollstop": "^1.2.0",
-    "underscore": "1.4.4"
+    "underscore": "1.8.3"
   },
   "config": {
     "travis-cov": {

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -2,6 +2,7 @@
 'use strict';
 var $ = require('jquery');
 var _ = require('underscore');
+var markerlessRE = /p\d+/;
 
 // indexOf polyfill
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf
@@ -76,7 +77,7 @@ module.exports = {
     // **Returns** Reg entity marker formatted for human readability
     idToRef: function(id) {
         var ref = '';
-        var parts, i, len, dividers, item, interpIndex, interpParts, subpartIndex;
+        var parts, i, len, dividers, item, interpIndex, interpParts, subpartIndex, markerlessIndex;
         parts = id.split('-');
         len = parts.length - 1;
         subpartIndex = parts.indexOf('Subpart');
@@ -125,8 +126,14 @@ module.exports = {
         // the second part of a supplement to an appendix
         if (len === 1 && isNaN(parts[1])) {
             return ref += parts[1];
+        // we have a paragraph
         } else {
-            // we have a paragraph
+            // trim anything after a markerless paragraph
+            markerlessIndex = _.findIndex(parts, markerlessRE.test.bind(markerlessRE));
+            if (markerlessIndex !== -1) {
+              parts = parts.slice(0, markerlessIndex);
+              len = parts.length - 1;
+            }
             for (i = 0; i <= len; i++) {
                 // return part number alone
                 if (len < 1) {

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -76,7 +76,8 @@ module.exports = {
     //
     // **Returns** Reg entity marker formatted for human readability
     idToRef: function(id) {
-        var ref = '';
+        var ref = '',
+            isAppendix = this.isAppendix(id);
         var parts, i, len, dividers, item, interpIndex, interpParts, subpartIndex, markerlessIndex;
         parts = id.split('-');
         len = parts.length - 1;
@@ -109,7 +110,7 @@ module.exports = {
             ref += this.interpId(interpParts);
         }
         // if we have an appendix
-        else if (isNaN(parseInt(parts[1], 10))) {
+        else if (isAppendix) {
             return this.appendixId(parts[0], parts[1]);
         }
 
@@ -124,7 +125,7 @@ module.exports = {
         }
 
         // the second part of a supplement to an appendix
-        if (len === 1 && isNaN(parts[1])) {
+        if (len === 1 && isAppendix) {
             return ref += parts[1];
         // we have a paragraph
         } else {
@@ -261,7 +262,7 @@ module.exports = {
                 return false;
             }
 
-            if (isNaN(parts[1]) && parts[1].toLowerCase() !== 'interp') {
+            if (isNaN(parts[1].substr(0, 1)) && parts[1].toLowerCase() !== 'interp') {
                 return true;
             }
         }

--- a/regulations/static/regulations/js/unittests/specs/helpers-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/helpers-spec.js
@@ -50,6 +50,8 @@ describe('Non-DOM Helper functions:', function() {
 
         expect('§234.4(a)(2)').to.equal(Helpers.idToRef('234-4-a-2'));
 
+        expect('§234.4a').to.equal(Helpers.idToRef('234-4a'));
+
         expect('§87324.34(b)(23)(iv)(H)').to.equal(Helpers.idToRef('87324-34-b-23-iv-H'));
 
         expect('§87324.34(b)(23)').to.equal(Helpers.idToRef('87324-34-b-23-p6-iv-H'));

--- a/regulations/static/regulations/js/unittests/specs/helpers-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/helpers-spec.js
@@ -52,6 +52,8 @@ describe('Non-DOM Helper functions:', function() {
 
         expect('§87324.34(b)(23)(iv)(H)').to.equal(Helpers.idToRef('87324-34-b-23-iv-H'));
 
+        expect('§87324.34(b)(23)').to.equal(Helpers.idToRef('87324-34-b-23-p6-iv-H'));
+
         expect('Appendix X to Part 983').to.equal(Helpers.idToRef('983-X-4'));
 
         expect('Supplement I to Part 13').to.equal(Helpers.idToRef('13-Interp'));
@@ -66,7 +68,7 @@ describe('Non-DOM Helper functions:', function() {
 
         expect('Appendix A1 to Part 345').to.equal(Helpers.idToRef('345-A1'));
 
-        expect ('Supplement I to Appendices').to.equal(Helpers.idToRef('Appendices-1'));
+        expect('Supplement I to Appendices').to.equal(Helpers.idToRef('Appendices-1'));
     });
 
     it('findBaseSection should find base sections of any id', function() {

--- a/regulations/templates/regulations/toc-subjgrp.html
+++ b/regulations/templates/regulations/toc-subjgrp.html
@@ -1,4 +1,4 @@
-<li data-subpart-heading><h3 class="subpart-heading" data-section-id="{{item.section_id}}">{{item.label|safe|upper}}</h3></li>
+<li><h3 class="subpart-heading" data-section-id="{{item.section_id}}">{{item.label|safe|upper}}</h3></li>
 
 {% if item.sub_toc %}
     {% for item in item.sub_toc %}


### PR DESCRIPTION
Builds on #19 ([diff](https://github.com/cmc333333/regulations-site/compare/cmc333333:sync-with-cfpb...cmc333333:header-fixes))

* Resolves 18F/atf-eregs#8 by cutting off label parts that begin with a markerless paragraph. The logic doesn't _quite_ mirror what's in the backend Python, but close enough
* Resolves 18F/atf-eregs#13 by defining appendices as _beginning_ with a letter
* Resolves 18F/atf-eregs#10 by not flagging subject groups the same way subparts are. The JS then uses the _previous_ subpart, which is exactly what we want to happen
* Also bumps up the version of underscore, so I could use `findIndex`