### PR TITLE
Clean up EXTRACTs

### DIFF
--- a/regulations/templates/regulations/layers/extract.html
+++ b/regulations/templates/regulations/layers/extract.html
@@ -1,0 +1,9 @@
+{% comment %}
+    Extracts and Notes are visually separate from the rest of the text, used
+    as block quotes, examples, etc.
+{% endcomment %}
+<div class="appendix-note inline-interpretation">
+    {% for line in lines %}
+    <p>{{ line }}</p>
+    {% endfor %}
+</div>

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from unittest import TestCase
 
 from mock import Mock, patch
@@ -6,134 +7,70 @@ from regulations.generator.layers.formatting import FormattingLayer
 
 
 class FormattingLayerTest(TestCase):
-    @patch('regulations.generator.layers.formatting.loader')
-    def test_apply_layer(self, loader):
-        render = loader.get_template.return_value.render
-
-        table_data = {'header': [[{'colspan': 2, 'rowspan': 1,
-                                   'text': 'Title'}]],
-                      'rows': [['cell 11', 'cell 12'], ['cell 21', 'cell 22']]}
-        data = {'111-1': [],
-                '111-2': [{}],
-                '111-3': [{'text': 'original', 'locations': [0, 2],
-                                   'table_data': table_data}]}
-        fl = FormattingLayer(data)
+    def test_empty(self):
+        """FormattingLayer ignores empty of missing node labels"""
+        data = {'111-1': [], '111-2': [{}]}
+        with patch('regulations.generator.layers.formatting.loader') as ldr:
+            render = ldr.get_template.return_value.render
+            fl = FormattingLayer(data)
         self.assertEqual([], fl.apply_layer('111-0'))
         self.assertEqual([], fl.apply_layer('111-1'))
         self.assertEqual([], fl.apply_layer('111-2'))
         self.assertFalse(render.called)
 
-        result = fl.apply_layer('111-3')
+    def assert_context_contains(self, template_name, data_key, data_value,
+                                expected_context=None):
+        """Verify that FormattingLayer converts the `data` elements into a
+        context variable similar to `expect_context`. If `expected_context` is
+        not provided, assume that it should match `data_value`"""
+        if expected_context is None:
+            expected_context = dict(data_value)
+        data = {'111-3': [{'text': 'original', 'locations': [0, 2],
+                           data_key: data_value}]}
+        template_file = 'regulations/layers/{}.html'.format(template_name)
+        with patch('regulations.generator.layers.formatting.loader') as ldr:
+            # we will want to reference these templates later
+            templates = defaultdict(Mock)
+            ldr.get_template.side_effect = templates.__getitem__
+            fl = FormattingLayer(data)
+            result = fl.apply_layer('111-3')
+            render = templates[template_file].render
+
         self.assertEqual(len(result), 1)
         self.assertEqual('original', result[0][0])
         self.assertEqual([0, 2], result[0][2])
+
         self.assertTrue(render.called)
         context = render.call_args[0][0]
-        self.assertEqual(context['header'],
-                         [[{'colspan': 2, 'rowspan': 1, 'text': 'Title'}]])
+        for key, value in expected_context.iteritems():
+            self.assertTrue(key in context)
+            self.assertEqual(context[key], value)
 
-    @patch('regulations.generator.layers.formatting.loader')
-    def test_apply_layer_note(self, loader):
-        note_mock = Mock()
-        loader.get_template.side_effect = lambda arg: note_mock if "note" in arg else Mock()
-        render = note_mock.render
+    def test_apply_layer_table(self):
+        data = {'header': [[{'colspan': 2, 'rowspan': 1, 'text': 'Title'}]],
+                'rows': [['cell 11', 'cell 12'], ['cell 21', 'cell 22']]}
+        self.assert_context_contains('table', 'table_data', data)
 
-        fence_data = {'type': 'note',
-                      'lines': ['Note:', '1. Content1', '2. Content2']}
-        data = {'111-1': [],
-                '111-2': [{}],
-                '111-3': [{'text': 'original', 'locations': [0],
-                           'fence_data': fence_data}]}
-        fl = FormattingLayer(data)
-        self.assertEqual([], fl.apply_layer('111-0'))
-        self.assertEqual([], fl.apply_layer('111-1'))
-        self.assertEqual([], fl.apply_layer('111-2'))
-        self.assertFalse(render.called)
+    def test_apply_layer_note(self):
+        data = {'type': 'note',
+                'lines': ['Note:', '1. Content1', '2. Content2']}
+        expected = {'lines': ['1. Content1', '2. Content2'], 'type': 'note'}
+        self.assert_context_contains('note', 'fence_data', data, expected)
 
-        result = fl.apply_layer('111-3')
-        self.assertEqual(len(result), 1)
-        self.assertEqual('original', result[0][0])
-        self.assertEqual([0], result[0][2])
-        self.assertTrue(render.called)
-        context = render.call_args[0][0]
-        self.assertEqual(context['lines'],
-                         ['1. Content1', '2. Content2'])
+    def test_apply_layer_code(self):
+        data = {'type': 'python',
+                'lines': ['def double(x):', '    return x + x']}
+        self.assert_context_contains('code', 'fence_data', data)
 
-    @patch('regulations.generator.layers.formatting.loader')
-    def test_apply_layer_code(self, loader):
-        code_mock = Mock()
-        loader.get_template.side_effect = lambda arg: code_mock if "code" in arg else Mock()
-        render = code_mock.render
+    def test_apply_layer_extract(self):
+        data = {'type': 'extract',
+                'lines': ['Some Notes:', 'More content']}
+        self.assert_context_contains('extract', 'fence_data', data)
 
-        fence_data = {'type': 'python',
-                      'lines': ['def double(x):', '    return x + x']}
-        data = {'111-1': [],
-                '111-2': [{}],
-                '111-3': [{'text': 'original', 'locations': [0],
-                           'fence_data': fence_data}]}
-        fl = FormattingLayer(data)
-        self.assertEqual([], fl.apply_layer('111-0'))
-        self.assertEqual([], fl.apply_layer('111-1'))
-        self.assertEqual([], fl.apply_layer('111-2'))
-        self.assertFalse(render.called)
+    def test_apply_layer_subscript(self):
+        data = {'variable': 'abc', 'subscript': '123'}
+        self.assert_context_contains('subscript', 'subscript_data', data)
 
-        result = fl.apply_layer('111-3')
-        self.assertEqual(len(result), 1)
-        self.assertEqual('original', result[0][0])
-        self.assertEqual([0], result[0][2])
-        self.assertTrue(render.called)
-        context = render.call_args[0][0]
-        self.assertEqual(context['lines'],
-                         ['def double(x):', '    return x + x'])
-
-    @patch('regulations.generator.layers.formatting.loader')
-    def test_apply_layer_subscript(self, loader):
-        subscript_mock = Mock()
-        loader.get_template.side_effect = lambda arg: subscript_mock if "subscript" in arg else Mock()
-        render = subscript_mock.render
-
-        subscript_data = {'variable': 'abc', 'subscript': '123'}
-        data = {'111-1': [],
-                '111-2': [{}],
-                '111-3': [{'text': 'abc_{123}', 'locations': [0, 1, 2],
-                           'subscript_data': subscript_data}]}
-        fl = FormattingLayer(data)
-        self.assertEqual([], fl.apply_layer('111-0'))
-        self.assertEqual([], fl.apply_layer('111-1'))
-        self.assertEqual([], fl.apply_layer('111-2'))
-        self.assertFalse(render.called)
-
-        result = fl.apply_layer('111-3')
-        self.assertEqual(len(result), 1)
-        self.assertEqual('abc_{123}', result[0][0])
-        self.assertEqual([0, 1, 2], result[0][2])
-        self.assertTrue(render.called)
-        context = render.call_args[0][0]
-        self.assertEqual(context['variable'], 'abc')
-        self.assertEqual(context['subscript'], '123')
-
-
-    @patch('regulations.generator.layers.formatting.loader')
-    def test_apply_layer_dash(self, loader):
-        dash_mock = Mock()
-        loader.get_template.side_effect = lambda arg: dash_mock if "dash" in arg else Mock()
-        render = dash_mock.render
-
-        dash_data = {'text': 'This is an fp-dash'}
-        data = {'111-1': [],
-                '111-2': [{}],
-                '111-3': [{'text': 'This is an fp-dash_____', 'locations': [0],
-                           'dash_data': dash_data}]}
-        fl = FormattingLayer(data)
-        self.assertEqual([], fl.apply_layer('111-0'))
-        self.assertEqual([], fl.apply_layer('111-1'))
-        self.assertEqual([], fl.apply_layer('111-2'))
-        self.assertFalse(render.called)
-
-        result = fl.apply_layer('111-3')
-        self.assertEqual(len(result), 1)
-        self.assertEqual('This is an fp-dash_____', result[0][0])
-        self.assertEqual([0], result[0][2])
-        self.assertTrue(render.called)
-        context = render.call_args[0][0]
-        self.assertEqual(context['text'], 'This is an fp-dash')
+    def test_apply_layer_dash(self):
+        data = {'text': 'This is an fp-dash'}
+        self.assert_context_contains('dash', 'dash_data', data)


### PR DESCRIPTION
Builds on #19 ([diff](https://github.com/cmc333333/regulations-site/compare/sync-with-cfpb...cmc333333:11-extract))

Resolves 18F/atf-eregs#11 by adding a template specifically for extracts. Also removes a lot of redundancy in the formatting layer and associated tests

Looks like (bold is an unrelated [bug](/18F/atf-eregs/issues/19)): 
<img width="655" alt="screen shot 2015-09-14 at 6 06 07 pm" src="https://cloud.githubusercontent.com/assets/326918/9863121/56c6327c-5b0b-11e5-88ff-ab92a2e3dd28.png">
