### PR TITLE
Add compile_frontend Django command

### DIFF
--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -1,0 +1,12 @@
+from optparse import make_option
+from django.core.management.base import BaseCommand, CommandError
+
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
+        make_option('--long', '-l', dest='long',
+            help='Help for the long options'),
+    )
+    help = 'Help text goes here'
+
+    def handle(self, **options):
+         print "This is a command"

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -1,12 +1,61 @@
-from optparse import make_option
+import codecs
+import distutils
+from os import environ, mkdir, path
+import regulations
+import shutil
+import subprocess
+
 from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
 
 class Command(BaseCommand):
-    option_list = BaseCommand.option_list + (
-        make_option('--long', '-l', dest='long',
-            help='Help for the long options'),
-    )
-    help = 'Help text goes here'
+    help = 'Build the frontend, including overrides.'
 
-    def handle(self, **options):
-         print "This is a command"
+    def find_regulations_directory(self):
+        child = regulations.__file__
+        child_dir = path.split(child)[0]
+        return path.split(child_dir)[0]
+
+    def run_collectstatic(self):
+        call_command("collectstatic", noinput=True)
+
+    def write_file(self, filename, markup):
+        """ Write out a file using the UTF-8 codec. """
+        f = codecs.open(filename, 'w', encoding='utf-8')
+        f.write(markup)
+        f.close()
+
+    def get_regulation_version(self, **options):
+        """ Get the regulation part and regulation version from the command line arguments. """
+        regulation_part = options.get('regulation_part')
+        regulation_version = options.get('regulation_version')
+
+        if not regulation_part or not regulation_version:
+            usage_string = "Usage: python manage.py generate_regulation  %s\n"  % Command.args
+            raise CommandError(usage_string)
+        return (regulation_part, regulation_version)
+
+    def handle(self, *args, **options):
+        import rlcompleter; import pdb; zcomp = locals(); zcomp.update(globals()); pdb.Pdb.complete = rlcompleter.Completer(zcomp).complete; pdb.set_trace()
+        """
+        target = "./frontend_build"
+        # put in some checks before this?
+        shutil.rmtree("./compiled")
+        environ["TMDDIR"] = target
+        self.run_collectstatic()
+        regulations_directory = self.find_regulations_directory()
+        for f in (
+            "package.json",
+            "bower.json",
+            "Gruntfile.js",
+            ".eslintrc"
+        ):
+            shutil.copy("%s/%s" %(regulations_directory, f), target)
+        with codecs.open("%s/config.json" % target, "w", encoding="utf-8") as f:
+            f.write('{"frontEndPath": "static/regulations"}')
+        os.chdir(target)
+        return_code = subprocess.call(["npm", "install", "grunt-cli", "bower"])
+        return_code = subprocess.call(["npm", "install"])
+        shutil.copytree("./static/regulations", "../compiled")
+        os.chdir("..")
+        """

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -31,9 +31,6 @@ class Command(BaseCommand):
         child_dir = os.path.split(child)[0]
         return os.path.split(child_dir)[0]
 
-    def run_collectstatic(self):
-        subprocess.call(["python", "manage.py", "collectstatic", "--noinput"])
-
     def handle(self, *args, **options):
         build_dir = "./frontend_build"
         target_dir = "./compiled"
@@ -41,7 +38,7 @@ class Command(BaseCommand):
             if os.path.exists(dirpath):
                 shutil.rmtree(dirpath)
         os.environ["TMPDIR"] = build_dir
-        self.run_collectstatic()
+        subprocess.call(["python", "manage.py", "collectstatic", "--noinput"])
         regulations_directory = self.find_regulations_directory()
         frontend_files = (
             "package.json",

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -1,7 +1,7 @@
 import codecs
 import distutils
-from os import environ, mkdir, path
 import regulations
+import os
 import shutil
 import subprocess
 
@@ -13,8 +13,8 @@ class Command(BaseCommand):
 
     def find_regulations_directory(self):
         child = regulations.__file__
-        child_dir = path.split(child)[0]
-        return path.split(child_dir)[0]
+        child_dir = os.path.split(child)[0]
+        return os.path.split(child_dir)[0]
 
     def run_collectstatic(self):
         call_command("collectstatic", noinput=True)
@@ -37,11 +37,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         import rlcompleter; import pdb; zcomp = locals(); zcomp.update(globals()); pdb.Pdb.complete = rlcompleter.Completer(zcomp).complete; pdb.set_trace()
-        """
         target = "./frontend_build"
         # put in some checks before this?
         shutil.rmtree("./compiled")
-        environ["TMDDIR"] = target
+        os.environ["TMDDIR"] = target
         self.run_collectstatic()
         regulations_directory = self.find_regulations_directory()
         for f in (
@@ -58,4 +57,3 @@ class Command(BaseCommand):
         return_code = subprocess.call(["npm", "install"])
         shutil.copytree("./static/regulations", "../compiled")
         os.chdir("..")
-        """


### PR DESCRIPTION
This is intended to make it relatively easy for projects using regulations-site as a library to override CSS/JS/fonts/images with their own versions.