### PR TITLE
Don't display SUBJGRPs in the TOC of diffs

### DIFF
--- a/regulations/tests/views_diff_tests.py
+++ b/regulations/tests/views_diff_tests.py
@@ -134,43 +134,39 @@ class ChromeSectionDiffViewTests(TestCase):
 
 
 class PartialSectionDiffViewTests(TestCase):
+    def setUp(self):
+        self.versions = views_diff.Versions('old', 'new', 'from')
+        self.toc = [{'section_id': '9898-1'}, {'section_id': '9898-5'},
+                    {'section_id': '9898-A'}, {'section_id': '9898-Interp'}]
+        self.view = views_diff.PartialSectionDiffView()
+
+    def assert_url_contains_versions(self, url, section_id):
+        """The provided url should contain the appropriate strings for the
+        old, new, and return_to urls"""
+        from_version = '?from_versions=' + self.versions.return_to
+        self.assertTrue(self.versions.older in url)
+        self.assertTrue(self.versions.newer in url)
+        self.assertTrue(from_version in url)
+        self.assertTrue(section_id in url)
+
+    def assert_correct_nav(self, section_id, prev, following):
+        """Verify that the generated nav contains the appropriate url entries
+        for prev and next"""
+        nav = self.view.footer_nav(section_id, self.toc, self.versions)
+        if prev:
+            self.assert_url_contains_versions(nav['previous']['url'], prev)
+        else:
+            self.assertFalse('previous' in nav)
+
+        if following:
+            self.assert_url_contains_versions(nav['next']['url'], following)
+        else:
+            self.assertFalse('next' in nav)
+
     def test_footer_nav(self):
-        view = views_diff.PartialSectionDiffView()
-        versions = views_diff.Versions('old', 'new', 'from')
-        toc = [{'section_id': '9898-1'}, {'section_id': '9898-5'},
-               {'section_id': '9898-A'}, {'section_id': '9898-Interp'}]
-        self.assertEqual({}, view.footer_nav('9898-2', toc, versions))
-
-        result = view.footer_nav('9898-1', toc, versions)
-        self.assertFalse('previous' in result)
-        self.assertTrue('9898-5' in result['next']['url'])
-        self.assertTrue('old' in result['next']['url'])
-        self.assertTrue('new' in result['next']['url'])
-        self.assertTrue('?from_version=from' in result['next']['url'])
-
-        result = view.footer_nav('9898-5', toc, versions)
-        self.assertTrue('9898-1' in result['previous']['url'])
-        self.assertTrue('old' in result['previous']['url'])
-        self.assertTrue('new' in result['previous']['url'])
-        self.assertTrue('?from_version=from' in result['previous']['url'])
-        self.assertTrue('9898-A' in result['next']['url'])
-        self.assertTrue('old' in result['next']['url'])
-        self.assertTrue('new' in result['next']['url'])
-        self.assertTrue('?from_version=from' in result['next']['url'])
-
-        result = view.footer_nav('9898-A', toc, versions)
-        self.assertTrue('9898-5' in result['previous']['url'])
-        self.assertTrue('old' in result['previous']['url'])
-        self.assertTrue('new' in result['previous']['url'])
-        self.assertTrue('?from_version=from' in result['previous']['url'])
-        self.assertTrue('9898-Interp' in result['next']['url'])
-        self.assertTrue('old' in result['next']['url'])
-        self.assertTrue('new' in result['next']['url'])
-        self.assertTrue('?from_version=from' in result['next']['url'])
-
-        result = view.footer_nav('9898-Interp', toc, versions)
-        self.assertTrue('9898-A' in result['previous']['url'])
-        self.assertTrue('old' in result['previous']['url'])
-        self.assertTrue('new' in result['previous']['url'])
-        self.assertTrue('?from_version=from' in result['previous']['url'])
-        self.assertFalse('next' in result)
+        self.assert_correct_nav('9898-2', prev=None, following=None)
+        self.assert_correct_nav('9898-1', prev=None, following='9898-5')
+        self.assert_correct_nav('9898-5', prev='9898-1', following='9898-A')
+        self.assert_correct_nav('9898-A', prev='9898-5',
+                                following='9898-Interp')
+        self.assert_correct_nav('9898-Interp', prev='9898-A', following=None)

--- a/regulations/tests/views_diff_tests.py
+++ b/regulations/tests/views_diff_tests.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from django.test import RequestFactory
 from mock import patch
 
-from regulations.views.diff import *
+from regulations.views import diff as views_diff
 
 
 class ChromeSectionDiffViewTests(TestCase):
@@ -18,7 +18,7 @@ class ChromeSectionDiffViewTests(TestCase):
             'sub_toc': sub},
             {'section_id': '8888-Interp', 'index': ['8888', 'Interp']}]
 
-        sections = extract_sections(toc)
+        sections = views_diff.extract_sections(toc)
         self.assertEqual(['8888', '1'], sections[0]['index'])
         self.assertEqual(['8888', '3'], sections[1]['index'])
         self.assertEqual(['8888', 'Interp'], sections[2]['index'])
@@ -26,7 +26,7 @@ class ChromeSectionDiffViewTests(TestCase):
     def test_extract_sections(self):
         toc = [{'section_id': '8888-1', 'index': ['8888', '1']},
                {'section_id': '8888-3', 'index': ['8888', '3']}]
-        sections = extract_sections(toc)
+        sections = views_diff.extract_sections(toc)
 
         self.assertEqual(['8888', '1'], sections[0]['index'])
         self.assertEqual(['8888', '3'], sections[1]['index'])
@@ -56,7 +56,8 @@ class ChromeSectionDiffViewTests(TestCase):
             '8888-B-1': {'op': 'modified'}
         }
 
-        result = diff_toc('oldold', 'newnew', old_toc, diff, 'from_ver')
+        result = views_diff.diff_toc('oldold', 'newnew', old_toc, diff,
+                                     'from_ver')
         self.assertEqual(8, len(result))
         self.assertTrue('8888-1' in result[0]['url'])
         self.assertTrue('?from_version=from_ver' in result[0]['url'])
@@ -118,9 +119,9 @@ class ChromeSectionDiffViewTests(TestCase):
             'label_id': '111-222',
             'version': '2'}
         request = RequestFactory().get('?new_version=1')
-        csdv = ChromeSectionDiffView()
+        csdv = views_diff.ChromeSectionDiffView()
         csdv.request = request
-        
+
         csdv.add_diff_content(context)
         self.assertEqual(context['from_version'], '2')
         self.assertEqual(context['left_version'], '2')
@@ -134,7 +135,7 @@ class ChromeSectionDiffViewTests(TestCase):
 
 class PartialSectionDiffViewTests(TestCase):
     def test_footer_nav(self):
-        view = PartialSectionDiffView()
+        view = views_diff.PartialSectionDiffView()
         toc = [{'section_id': '9898-1'}, {'section_id': '9898-5'},
                {'section_id': '9898-A'}, {'section_id': '9898-Interp'}]
         self.assertEqual({}, view.footer_nav(

--- a/regulations/tests/views_diff_tests.py
+++ b/regulations/tests/views_diff_tests.py
@@ -33,6 +33,7 @@ class ChromeSectionDiffViewTests(TestCase):
 
     def test_diff_toc(self):
         """Integration test."""
+        versions = views_diff.Versions('oldold', 'newnew', 'from_ver')
         old_toc = [{'section_id': '8888-1', 'index': ['8888', '1'],
                     'is_section':True},
                    {'section_id': '8888-3', 'index': ['8888', '3'],
@@ -56,8 +57,7 @@ class ChromeSectionDiffViewTests(TestCase):
             '8888-B-1': {'op': 'modified'}
         }
 
-        result = views_diff.diff_toc('oldold', 'newnew', old_toc, diff,
-                                     'from_ver')
+        result = views_diff.diff_toc(versions, old_toc, diff)
         self.assertEqual(8, len(result))
         self.assertTrue('8888-1' in result[0]['url'])
         self.assertTrue('?from_version=from_ver' in result[0]['url'])
@@ -136,19 +136,19 @@ class ChromeSectionDiffViewTests(TestCase):
 class PartialSectionDiffViewTests(TestCase):
     def test_footer_nav(self):
         view = views_diff.PartialSectionDiffView()
+        versions = views_diff.Versions('old', 'new', 'from')
         toc = [{'section_id': '9898-1'}, {'section_id': '9898-5'},
                {'section_id': '9898-A'}, {'section_id': '9898-Interp'}]
-        self.assertEqual({}, view.footer_nav(
-            '9898-2', toc, 'old', 'new', 'from'))
+        self.assertEqual({}, view.footer_nav('9898-2', toc, versions))
 
-        result = view.footer_nav('9898-1', toc, 'old', 'new', 'from')
+        result = view.footer_nav('9898-1', toc, versions)
         self.assertFalse('previous' in result)
         self.assertTrue('9898-5' in result['next']['url'])
         self.assertTrue('old' in result['next']['url'])
         self.assertTrue('new' in result['next']['url'])
         self.assertTrue('?from_version=from' in result['next']['url'])
 
-        result = view.footer_nav('9898-5', toc, 'old', 'new', 'from')
+        result = view.footer_nav('9898-5', toc, versions)
         self.assertTrue('9898-1' in result['previous']['url'])
         self.assertTrue('old' in result['previous']['url'])
         self.assertTrue('new' in result['previous']['url'])
@@ -158,7 +158,7 @@ class PartialSectionDiffViewTests(TestCase):
         self.assertTrue('new' in result['next']['url'])
         self.assertTrue('?from_version=from' in result['next']['url'])
 
-        result = view.footer_nav('9898-A', toc, 'old', 'new', 'from')
+        result = view.footer_nav('9898-A', toc, versions)
         self.assertTrue('9898-5' in result['previous']['url'])
         self.assertTrue('old' in result['previous']['url'])
         self.assertTrue('new' in result['previous']['url'])
@@ -168,7 +168,7 @@ class PartialSectionDiffViewTests(TestCase):
         self.assertTrue('new' in result['next']['url'])
         self.assertTrue('?from_version=from' in result['next']['url'])
 
-        result = view.footer_nav('9898-Interp', toc, 'old', 'new', 'from')
+        result = view.footer_nav('9898-Interp', toc, versions)
         self.assertTrue('9898-A' in result['previous']['url'])
         self.assertTrue('old' in result['previous']['url'])
         self.assertTrue('new' in result['previous']['url'])

--- a/regulations/tests/views_diff_tests.py
+++ b/regulations/tests/views_diff_tests.py
@@ -9,19 +9,25 @@ from regulations.views import diff as views_diff
 class ChromeSectionDiffViewTests(TestCase):
 
     def test_extract_sections_subparts(self):
-        sub = [{'section_id': '8888-1', 'index': ['8888', '1']},
-               {'section_id': '8888-3', 'index': ['8888', '3']}]
+        sub1 = [{'section_id': '8888-1', 'index': ['8888', '1']},
+                {'section_id': '8888-3', 'index': ['8888', '3']}]
+        sub2 = [{'section_id': '8888-7', 'index': ['8888', '7']}]
 
-        toc = [{
-            'section_id': '8888-Subpart-A',
-            'index': ['8888', 'Subpart', 'A'],
-            'sub_toc': sub},
-            {'section_id': '8888-Interp', 'index': ['8888', 'Interp']}]
+        toc = [
+            {'section_id': '8888-Subpart-A',
+             'index': ['8888', 'Subpart', 'A'],
+             'sub_toc': sub1},
+            {'section_id': '8888-Subjgrp-IND',
+             'index': ['8888', 'Subjgrp', 'IND'],
+             'sub_toc': sub2},
+            {'section_id': '8888-Interp', 'index': ['8888', 'Interp']},
+        ]
 
         sections = views_diff.extract_sections(toc)
         self.assertEqual(['8888', '1'], sections[0]['index'])
         self.assertEqual(['8888', '3'], sections[1]['index'])
-        self.assertEqual(['8888', 'Interp'], sections[2]['index'])
+        self.assertEqual(['8888', '7'], sections[2]['index'])
+        self.assertEqual(['8888', 'Interp'], sections[3]['index'])
 
     def test_extract_sections(self):
         toc = [{'section_id': '8888-1', 'index': ['8888', '1']},
@@ -143,7 +149,7 @@ class PartialSectionDiffViewTests(TestCase):
     def assert_url_contains_versions(self, url, section_id):
         """The provided url should contain the appropriate strings for the
         old, new, and return_to urls"""
-        from_version = '?from_versions=' + self.versions.return_to
+        from_version = '?from_version=' + self.versions.return_to
         self.assertTrue(self.versions.older in url)
         self.assertTrue(self.versions.newer in url)
         self.assertTrue(from_version in url)

--- a/regulations/tests/views_navigation_tests.py
+++ b/regulations/tests/views_navigation_tests.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 from unittest import TestCase
 from mock import patch
 from regulations.views import navigation
@@ -9,22 +9,6 @@ class NavigationTest(TestCase):
         label = '204-1-a'
         self.assertEquals(
             ['204', '1', 'a'], navigation.get_labels(label))
-
-    def test_is_last(self):
-        l = [1, 2, 3]
-        self.assertFalse(navigation.is_last(1, l))
-        self.assertTrue(navigation.is_last(2, l))
-
-    def test_choose_next_section(self):
-        l = [1, 2, 3]
-        self.assertEquals(3, navigation.choose_next_section(1, l))
-        self.assertEquals(None, navigation.choose_next_section(2, l))
-
-    def test_choose_previous_section(self):
-        l = [1,  2, 3]
-        self.assertEquals(1, navigation.choose_previous_section(1, l))
-        self.assertEquals(2, navigation.choose_previous_section(2, l))
-        self.assertEquals(None, navigation.choose_previous_section(0, l))
 
     @patch('regulations.views.navigation.fetch_toc')
     def test_nav_sections(self, fetch_toc):

--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -8,8 +8,6 @@ from regulations.generator.section_url import SectionUrl
 from regulations.generator.toc import fetch_toc
 from regulations.views import error_handling, utils
 from regulations.views.chrome import ChromeView
-from regulations.views.navigation import choose_next_section
-from regulations.views.navigation import choose_previous_section
 from regulations.views.partial import PartialView
 
 from django.core.urlresolvers import reverse
@@ -49,20 +47,17 @@ class PartialSectionDiffView(PartialView):
             if toc_entry['section_id'] != label:
                 continue
 
-            p_sect = choose_previous_section(idx, toc)
-            n_sect = choose_next_section(idx, toc)
+            if idx > 0:
+                nav['previous'] = toc[idx - 1]
 
-            if p_sect:
-                nav['previous'] = p_sect
-                nav['previous']['url'] = reverse_chrome_diff_view(
-                    p_sect['section_id'], old_version,
-                    new_version, from_version)
+            if idx < len(toc) - 1:
+                nav['next'] = toc[idx + 1]
 
-            if n_sect:
-                nav['next'] = n_sect
-                nav['next']['url'] = reverse_chrome_diff_view(
-                    n_sect['section_id'], old_version,
-                    new_version, from_version)
+        # Add the url
+        for toc_entry in nav.values():
+            toc_entry['url'] = reverse_chrome_diff_view(
+                toc_entry['section_id'], old_version, new_version,
+                from_version)
         return nav
 
     def get_context_data(self, **kwargs):

--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -153,7 +153,7 @@ def reverse_chrome_diff_view(sect_id, left_ver, right_ver, from_version):
 def extract_sections(toc):
     compiled_toc = []
     for i in toc:
-        if 'Subpart' in i['index']:
+        if 'Subpart' in i['index'] or 'Subjgrp' in i['index']:
             compiled_toc.extend(i['sub_toc'])
         else:
             compiled_toc.append(i)

--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -1,4 +1,4 @@
-#vim: set encoding=utf-8
+# vim: set encoding=utf-8
 
 from regulations.generator import generator
 from regulations.generator.html_builder import HTMLBuilder
@@ -40,7 +40,7 @@ class PartialSectionDiffView(PartialView):
         try:
             return super(PartialSectionDiffView, self).get(request, *args,
                                                            **kwargs)
-        except error_handling.MissingContentException, e:
+        except error_handling.MissingContentException:
             return error_handling.handle_generic_404(request)
 
     def footer_nav(self, label, toc, old_version, new_version, from_version):
@@ -77,8 +77,8 @@ class PartialSectionDiffView(PartialView):
         tree = generator.get_tree_paragraph(label_id, older)
 
         if tree is None:
-            #TODO We need a more complicated check here to see if the diffs
-            #add the requested section. If not -> 404
+            # TODO We need a more complicated check here to see if the diffs
+            # add the requested section. If not -> 404
             tree = {}
 
         appliers = get_appliers(label_id, older, newer)
@@ -161,7 +161,7 @@ def extract_sections(toc):
 
 
 def diff_toc(older_version, newer_version, old_toc, diff, from_version):
-    #We work around Subparts in the TOC for now.
+    # We work around Subparts in the TOC for now.
     compiled_toc = extract_sections(old_toc)
 
     for node in (v['node'] for v in diff.values() if v['op'] == 'added'):
@@ -179,7 +179,7 @@ def diff_toc(older_version, newer_version, old_toc, diff, from_version):
 
     modified, deleted = modified_deleted_sections(diff)
     for el in compiled_toc:
-        if not 'Subpart' in el['index'] and not 'Subjgrp' in el['index']:
+        if 'Subpart' not in el['index'] and 'Subjgrp' not in el['index']:
             el['url'] = reverse_chrome_diff_view(
                 el['section_id'], older_version, newer_version, from_version)
         # Deleted first, lest deletions in paragraphs affect the section

--- a/regulations/views/navigation.py
+++ b/regulations/views/navigation.py
@@ -6,20 +6,6 @@ def get_labels(current):
     return current.split('-')
 
 
-def is_last(i, l):
-    return i+1 == len(l)
-
-
-def choose_next_section(i, toc_up):
-    if not is_last(i, toc_up):
-        return toc_up[i+1]
-
-
-def choose_previous_section(i, toc_up):
-    if i > 0:
-        return toc_up[i-1]
-
-
 def _add_extra(el, version):
     """Add extra fields to a TOC element -- only added to elements we will
     use for prev/next"""


### PR DESCRIPTION
We don't display subparts in the diff TOC; follow the same logic for subjgrps. Resolves 18F/atf-eregs#47

b9ff8ab7dd4673853341b654f09f9c32813edfc7 is the only commit that adds new logic -- very simple

All the other commits are clean up -- see the individual changesets for specifics.