### PR TITLE
Tweaks to compile_frontend functionality

### DIFF
--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -1,5 +1,4 @@
 import codecs
-import logging
 import os
 import shutil
 import subprocess
@@ -86,7 +85,8 @@ class Command(BaseCommand):
                 prefixed_path = path
 
             if prefixed_path in files_seen:
-                logging.info("Using override for %s", prefixed_path)
+                self.stdout.write(
+                    "Using override for {}\n".format(prefixed_path))
             else:
                 files_seen.add(prefixed_path)
                 with storage.open(path) as source_file:

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -1,17 +1,15 @@
 import codecs
-import distutils
 import regulations
 import os
 import shutil
 import subprocess
 
-from django.core.management.base import BaseCommand, CommandError
-from django.core.management import call_command
+from django.core.management.base import BaseCommand
 
 """
 This command compiles the frontend for regulations-site after using the Django
-``collectstatic`` command to override specific files, and places the output in a
-directory named ``compiled`` at the root level of the project.
+``collectstatic`` command to override specific files, and places the output in
+a directory named ``compiled`` at the root level of the project.
 
 For example, the atf-eregs project uses ``regulations-site`` as a library and
 overrides the contents of the
@@ -23,22 +21,26 @@ and the results are copied into ``compiled``, which can then be used as the
 static directory for the CSS, font, JavaScript, and image assets.
 
 """
+
+
 class Command(BaseCommand):
     help = 'Build the frontend, including local overrides.'
+    BUILD_DIR = "./frontend_build"
+    TARGET_DIR = "./compiled/regulations"
 
     def find_regulations_directory(self):
         child = regulations.__file__
         child_dir = os.path.split(child)[0]
         return os.path.split(child_dir)[0]
 
-    def handle(self, *args, **options):
-        build_dir = "./frontend_build"
-        target_dir = "./compiled/regulations"
-        for dirpath in (build_dir, target_dir):
+    def remove_dirs(self):
+        """Remove existing output dirs"""
+        for dirpath in (self.BUILD_DIR, self.TARGET_DIR):
             if os.path.exists(dirpath):
                 shutil.rmtree(dirpath)
-        os.environ["TMPDIR"] = build_dir
-        subprocess.call(["python", "manage.py", "collectstatic", "--noinput"])
+
+    def copy_configs(self):
+        """Copy over configs from regulations"""
         regulations_directory = self.find_regulations_directory()
         frontend_files = (
             "package.json",
@@ -47,13 +49,32 @@ class Command(BaseCommand):
             ".eslintrc"
         )
         for f_file in frontend_files:
-            source = "%s/%s" %(regulations_directory, f_file)
-            shutil.copy(source, "%s/" % build_dir)
-        with codecs.open("%s/config.json" % build_dir, "w",
+            source = "%s/%s" % (regulations_directory, f_file)
+            shutil.copy(source, "%s/" % self.BUILD_DIR)
+        with codecs.open("%s/config.json" % self.BUILD_DIR, "w",
                          encoding="utf-8") as f:
             f.write('{"frontEndPath": "static/regulations"}')
-        os.chdir(build_dir)
+
+    def collect_files(self):
+        """Fetch all of the static files from the installed apps -- put them
+        into a specific directory"""
+        os.environ["TMPDIR"] = self.BUILD_DIR
+        subprocess.call(["python", "manage.py", "collectstatic", "--noinput"])
+
+    def build_frontend(self):
+        """Shell out to npm for building the frontend files"""
+        os.chdir(self.BUILD_DIR)
         subprocess.call(["npm", "install", "grunt-cli", "bower"])
         subprocess.call(["npm", "install"])
         os.chdir("..")
-        shutil.copytree("%s/static/regulations" % build_dir, target_dir)
+
+    def cleanup(self):
+        shutil.copytree("%s/static/regulations" % self.BUILD_DIR,
+                        self.TARGET_DIR)
+
+    def handle(self, *args, **options):
+        self.remove_dirs()
+        self.copy_configs()
+        self.collect_files()
+        self.build_frontend()
+        self.cleanup()

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -41,10 +41,21 @@ class Command(BaseCommand):
 
     def remove_dirs(self):
         """Remove existing output dirs"""
-        for dirpath in (self.BUILD_DIR, self.TARGET_DIR):
-            if os.path.exists(dirpath):
-                shutil.rmtree(dirpath)
-        os.mkdir(self.BUILD_DIR)
+        if os.path.exists(self.TARGET_DIR):
+            shutil.rmtree(self.TARGET_DIR)
+        # Delete everything in BUILD_DIR except node_modules, which we use for
+        # caching the downloaded node libraries
+        if os.path.exists(self.BUILD_DIR):
+            files = filter(os.path.isfile, os.listdir(self.BUILD_DIR))
+            dirs = filter(os.path.isdir, os.listdir(self.BUILD_DIR))
+            for f in files:
+                os.rm(os.path.join(self.BUILD_DIR, f))
+
+            for d in dirs:
+                if d != 'node_modules':
+                    shutil.rmtree(os.path.join(self.BUILD_DIR, d))
+        else:
+            os.mkdir(self.BUILD_DIR)
 
     def copy_configs(self):
         """Copy over configs from regulations"""
@@ -95,7 +106,6 @@ class Command(BaseCommand):
     def build_frontend(self):
         """Shell out to npm for building the frontend files"""
         os.chdir(self.BUILD_DIR)
-        subprocess.call(["npm", "install", "grunt-cli", "bower"])
         subprocess.call(["npm", "install"])
         os.chdir("..")
 

--- a/regulations/settings/dev.py
+++ b/regulations/settings/dev.py
@@ -3,11 +3,6 @@ from .base import *
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
-STATICFILES_DIRS = (
-    root('static'),
-)
-
-
 OFFLINE_OUTPUT_DIR = '/tmp/'
 
 INSTALLED_APPS += (


### PR DESCRIPTION
* Flake8 + split compile_frontend command into a few methods
* Don't shell out when running collectstatic -- instead call the static file finders and writer from within Python
* Skip over "compiled" when finding static files
* Allow the command to be ran within `regulations-site`, by falling back to "." as the input directory
* Reuse `node_modules` directory in between builds
* Don't install grunt-cli or bower -- we'll assume these are installed globally
* Remove a static dir that was present in the dev config -- it isn't needed

Part of 18F/atf-eregs#31