### PR TITLE
Give a bit more space to 3-column layout.

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -145,7 +145,7 @@ Secondary Content
     }
 
     .column-3+.column-3 {
-        margin-left: 4.5%;
+        margin-left: 4%;
     }
 
 }


### PR DESCRIPTION
Currently, the 3-column layout (when used) has three columns with 30% width,
and a margin of 4.5% on the last two columns. This leaves 1% for rendering
vagary. Unfortunately, as we've seen with ATF, this is not enough breathing
room. This bumps the wiggle room to 2%.

Resolves 18F/atf-eregs#44