### PR TITLE
Simple implementation for footnotes data

### DIFF
--- a/dummy_api/start.sh
+++ b/dummy_api/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git clone https://github.com/cfpb/regulations-core.git
+git clone https://github.com/18f/regulations-core.git
 cd regulations-core
 pip install -r requirements.txt
 

--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -6,16 +6,12 @@ class FormattingLayer(object):
 
     def __init__(self, layer_data):
         self.layer_data = layer_data
-        self.table_tpl = loader.get_template('regulations/layers/table.html')
-        self.note_tpl = loader.get_template('regulations/layers/note.html')
-        self.extract_tpl = loader.get_template(
-            'regulations/layers/extract.html')
-        self.code_tpl = loader.get_template('regulations/layers/code.html')
-        self.subscript_tpl = loader.get_template(
-            'regulations/layers/subscript.html')
-        self.dash_tpl = loader.get_template('regulations/layers/dash.html')
+        self.tpls = {
+            key: loader.get_template('regulations/layers/{}.html'.format(key))
+            for key in ('table', 'note', 'extract', 'code', 'subscript',
+                        'dash', 'footnote')}
 
-    def render_table(self, table):
+    def render_table(self, table, data_type=None):
         max_width = 0
         for header_row in table['header']:
             width = sum(cell['colspan'] for cell in header_row)
@@ -31,9 +27,9 @@ class FormattingLayer(object):
 
         context = Context(table)
         #   Remove new lines so that they don't get escaped on display
-        return self.table_tpl.render(context).replace('\n', '')
+        return self.tpls['table'].render(context).replace('\n', '')
 
-    def render_fence(self, fence):
+    def render_fence(self, fence, data_type=None):
         """Fenced paragraphs are formatted separately, offset from the rest of
         the text. They have an associated "type" which further specifies their
         format"""
@@ -44,37 +40,36 @@ class FormattingLayer(object):
             lines = [l.replace('Note:', '').replace('Notes:', '')
                      for l in lines]
             lines = [l for l in lines if l.strip()]
-            tpl = self.note_tpl
-        elif _type == 'extract':
+            tpl = self.tpls['note']
+        elif _type == 'extract':    # @todo can be removed soon
             lines = [l for l in lines if l.strip()]
-            tpl = self.extract_tpl
+            tpl = self.tpls['extract']
         else:   # Generic "code"/ preformatted
             strip_nl = False
-            tpl = self.code_tpl
+            tpl = self.tpls['code']
 
         rendered = tpl.render(Context({'lines': lines, 'type': _type}))
         if strip_nl:
             rendered = rendered.replace('\n', '')
         return rendered
 
-    def render_subscript(self, subscript):
-        context = Context(subscript)
-        return self.subscript_tpl.render(context).replace('\n', '')
-
-    def render_dash(self, dash):
-        context = Context(dash)
-        return self.dash_tpl.render(context).replace('\n', '')
+    def render_replacement(self, data, data_type):
+        """Several of the formatted data types are simple string replacements.
+        Implement them all here"""
+        context = Context(data)
+        return self.tpls[data_type].render(context).replace('\n', '')
 
     def apply_layer(self, text_index):
         """Convert all plaintext tables into html tables"""
         layer_pairs = []
-        data_types = ['table', 'fence', 'subscript', 'dash']
+        data_types = ['table', 'fence', 'subscript', 'dash', 'footnote']
         for data in self.layer_data.get(text_index, []):
             for data_type in data_types:
-                processor = getattr(self, 'render_' + data_type)
+                processor = getattr(self, 'render_' + data_type,
+                                    self.render_replacement)
                 key = data_type + '_data'
                 if key in data:
                     layer_pairs.append((data['text'],
-                                        processor(data[key]),
+                                        processor(data[key], data_type),
                                         data['locations']))
         return layer_pairs

--- a/regulations/templates/regulations/layers/footnote.html
+++ b/regulations/templates/regulations/layers/footnote.html
@@ -1,0 +1,5 @@
+{% comment %}
+  As a first pass, footnotes are displayed as hover text
+  Many of the styles here match regulations/layers/sxs-footnotes.html
+{% endcomment %}
+<sup><span title="{{ note }}">[{{ ref }}]</span></sup>

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -74,3 +74,7 @@ class FormattingLayerTest(TestCase):
     def test_apply_layer_dash(self):
         data = {'text': 'This is an fp-dash'}
         self.assert_context_contains('dash', 'dash_data', data)
+
+    def test_apply_layer_footnote(self):
+        data = {'ref': '123', 'note': "Here's the note"}
+        self.assert_context_contains('footnote', 'footnote_data', data)


### PR DESCRIPTION
Also reduces the growth of templates and custom functions as we add new formats.

UI step for implementing 18f/atf-eregs#55

Looks like
<img width="578" alt="footnote" src="https://cloud.githubusercontent.com/assets/326918/11049669/008d3d04-870e-11e5-897f-cb25bdf5c72b.png">
