### PR TITLE
Fix for compile_frontend / Squished table headers.

### DIFF
--- a/dummy_api/start.sh
+++ b/dummy_api/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-git clone https://github.com/cfpb/regulations-core.git
+git clone https://github.com/18f/regulations-core.git
 cd regulations-core
 pip install -r requirements.txt
 

--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -46,13 +46,12 @@ class Command(BaseCommand):
         # caching the downloaded node libraries
         if os.path.exists(self.BUILD_DIR):
             files = filter(os.path.isfile, os.listdir(self.BUILD_DIR))
-            dirs = filter(os.path.isdir, os.listdir(self.BUILD_DIR))
+            dirs = filter(os.path.isdir, [os.path.join(self.BUILD_DIR, f) for f in os.listdir(self.BUILD_DIR)])
             for f in files:
                 os.rm(os.path.join(self.BUILD_DIR, f))
-
             for d in dirs:
-                if d != 'node_modules':
-                    shutil.rmtree(os.path.join(self.BUILD_DIR, d))
+                if d != os.path.join(self.BUILD_DIR, 'node_modules'):
+                    shutil.rmtree(d)
         else:
             os.mkdir(self.BUILD_DIR)
 
@@ -77,13 +76,12 @@ class Command(BaseCommand):
         as pairs of (path, file)"""
         files_seen = set()
         pairs = (pr for finder in get_finders() for pr in finder.list([".*"]))
-        for path, storage in pairs:
+        for path, storage in pairs:            
             # Prefix the relative path if the source storage contains it
             if getattr(storage, 'prefix', None):
                 prefixed_path = os.path.join(storage.prefix, path)
             else:
                 prefixed_path = path
-
             if prefixed_path in files_seen:
                 self.stdout.write(
                     "Using override for {}\n".format(prefixed_path))

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -564,7 +564,7 @@ table {
     padding: 0;
     font-size: .75em;
     .avenir-next;
-    table-layout: fixed;
+    table-layout: auto;
     width: 100%;
 }
 


### PR DESCRIPTION
Static compiled files were not getting deleted on subsequent runs of compile_frontend.  Change table layout to auto to prevent table headers from getting truncated.