### PR TITLE
Return gray background to extracts

### DIFF
--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -8,8 +8,8 @@ class FormattingLayer(object):
         self.layer_data = layer_data
         self.tpls = {
             key: loader.get_template('regulations/layers/{}.html'.format(key))
-            for key in ('table', 'note', 'extract', 'code', 'subscript',
-                        'dash', 'footnote')}
+            for key in ('table', 'note', 'code', 'subscript', 'dash',
+                        'footnote')}
 
     def render_table(self, table, data_type=None):
         max_width = 0
@@ -41,9 +41,6 @@ class FormattingLayer(object):
                      for l in lines]
             lines = [l for l in lines if l.strip()]
             tpl = self.tpls['note']
-        elif _type == 'extract':    # @todo can be removed soon
-            lines = [l for l in lines if l.strip()]
-            tpl = self.tpls['extract']
         else:   # Generic "code"/ preformatted
             strip_nl = False
             tpl = self.tpls['code']

--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -20,6 +20,7 @@ Modules
 ------- */
 @import "module/navigation.less";
 @import "module/drawer.less";
+@import "module/extract.less";
 @import "module/interpretations.less";
 @import "module/header.less";
 @import "module/footer.less";

--- a/regulations/static/regulations/css/less/module/extract.less
+++ b/regulations/static/regulations/css/less/module/extract.less
@@ -1,0 +1,7 @@
+.extract {
+    background-color: @bg_gray;
+    padding: 0.125em .625em;
+    margin-bottom: 1em;
+    border-bottom: 0px;
+    position: relative;
+}

--- a/regulations/templates/regulations/layers/extract.html
+++ b/regulations/templates/regulations/layers/extract.html
@@ -1,9 +1,0 @@
-{% comment %}
-    Extracts and Notes are visually separate from the rest of the text, used
-    as block quotes, examples, etc.
-{% endcomment %}
-<div class="appendix-note inline-interpretation">
-    {% for line in lines %}
-    <p>{{ line }}</p>
-    {% endfor %}
-</div>

--- a/regulations/templates/regulations/tree-with-wrapper.html
+++ b/regulations/templates/regulations/tree-with-wrapper.html
@@ -7,6 +7,14 @@
     {% if not inline %}id="{{node.markup_id}}" data-permalink-section{% endif %}
     {% if node.interp %}data-interp-id="{{node.interp.markup_id}}"{% endif %}
 >
+    {% if node.node_type == "extract" %}
+    <div class="extract">
+    {% endif %}
+
     {% include "regulations/tree.html" %}
+
+    {% if node.node_type == "extract" %}
+    </div>
+    {% endif %}
 </li>
 

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -62,11 +62,6 @@ class FormattingLayerTest(TestCase):
                 'lines': ['def double(x):', '    return x + x']}
         self.assert_context_contains('code', 'fence_data', data)
 
-    def test_apply_layer_extract(self):
-        data = {'type': 'extract',
-                'lines': ['Some Notes:', 'More content']}
-        self.assert_context_contains('extract', 'fence_data', data)
-
     def test_apply_layer_subscript(self):
         data = {'variable': 'abc', 'subscript': '123'}
         self.assert_context_contains('subscript', 'subscript_data', data)


### PR DESCRIPTION
Also removes the code around treating fenced extracts -- that will no longer be generated.

Looks like
<img width="595" alt="screen shot 2015-11-16 at 4 29 10 pm" src="https://cloud.githubusercontent.com/assets/326918/11195319/672de98e-8c7f-11e5-893c-ff7d85c344fb.png">
<img width="605" alt="screen shot 2015-11-16 at 4 28 43 pm" src="https://cloud.githubusercontent.com/assets/326918/11195320/6731100a-8c7f-11e5-9781-4e98f924eaef.png">

Resolves 18f/atf-eregs#73