### PR TITLE
Add formatting layer to diffs

### DIFF
--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -30,7 +30,7 @@ def get_appliers(label_id, versions):
         raise error_handling.MissingContentException()
 
     appliers = utils.handle_diff_layers(
-        'graphics,paragraph,keyterms,defined',
+        'graphics,paragraph,keyterms,defined,formatting',
         label_id, versions.older, versions.newer)
     appliers += (diff,)
     return appliers


### PR DESCRIPTION
Was, e.g.
<img width="596" alt="screen shot 2015-11-20 at 9 56 46 am" src="https://cloud.githubusercontent.com/assets/326918/11302870/b6ce0910-8f6d-11e5-95cc-2dbcac7fbe03.png">

Now, e.g.
<img width="606" alt="screen shot 2015-11-20 at 9 57 11 am" src="https://cloud.githubusercontent.com/assets/326918/11302877/be52ef66-8f6d-11e5-8e1e-244131bbdfc6.png">

Resolves 18f/atf-eregs#66
