### PR TITLE
Don't assume all regs have letters

### DIFF
--- a/regulations/static/regulations/css/less/module/universal-landing.less
+++ b/regulations/static/regulations/css/less/module/universal-landing.less
@@ -118,7 +118,7 @@
         max-width: 75%;
     }
 
-    .reg-letter {
+    .reg-major-text {
         display: block;
         font-size: 1.375em;
     }

--- a/regulations/templates/regulations/generic_universal.html
+++ b/regulations/templates/regulations/generic_universal.html
@@ -53,8 +53,12 @@
                     <a href="{% url 'regulation_landing_view' regulation.part %}">
                         <span class="title-num">{{regulation.part}}</span>
                         <div class="reg-sub-title">
-                            <span class="reg-letter">Regulation {{regulation.meta.reg_letter}}</span>
-                            <span class="reg-title">{{regulation.meta.statutory_name|title}}</span>
+                            {% if regulation.meta.reg_letter %}
+                                <span class="reg-major-text">Regulation {{regulation.meta.reg_letter}}</span>
+                                <span class="reg-title">{{regulation.meta.statutory_name|title}}</span>
+                            {% else %}
+                                <span class="reg-major-text">{{regulation.meta.statutory_name|title}}</span>
+                            {% endif %}
                         </div>
                         <span class="cf-icon cf-icon-right-round"></span>
                     </a>


### PR DESCRIPTION
This patch modifies the universal landing page template/styles to accommodate
regulations without letters. In these cases, the regulation's statutory name
is given more prominence.

Compare: 
<img width="679" alt="screen shot 2015-11-26 at 11 19 09 pm" src="https://cloud.githubusercontent.com/assets/326918/11434046/12c79d1e-9494-11e5-86fb-8fce5a35e16a.png">

<img width="667" alt="screen shot 2015-11-26 at 11 19 18 pm" src="https://cloud.githubusercontent.com/assets/326918/11434047/16382c70-9494-11e5-8127-c89ef01be242.png">

Resolves 18f/atf-eregs#65
