### PR TITLE
Use child_ops data to order children in diffs

### DIFF
--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -13,8 +13,11 @@ class DiffApplier(object):
 
     INSERT = u'insert'
     DELETE = u'delete'
+    EQUAL = u'equal'
+
     DELETED_OP = 'deleted'
     ADDED_OP = 'added'
+    MODIFIED_OP = 'modified'
 
     def __init__(self, diff_json, label_requested):
         self.diff = diff_json
@@ -46,14 +49,31 @@ class DiffApplier(object):
         """ Mark all the text passed in as deleted. """
         return '<ins>' + text + '</ins>'
 
+    def set_child_labels(self, node):
+        """As we display removed, added, and unchanged nodes, the children of
+        a node will contain all three types. Pull the 'child_ops' data to
+        derive the correct order of these combined children"""
+        instructs = self.diff.get('-'.join(node['label']), {})
+        if 'child_labels' not in instructs and 'child_ops' in instructs:
+            original_labels = ['-'.join(c['label']) for c in node['children']]
+            new_labels = []
+            for op, start, end_or_nodes in instructs['child_ops']:
+                if isinstance(end_or_nodes, list):
+                    new_labels.extend(end_or_nodes)
+                else:
+                    new_labels.extend(original_labels[start:end_or_nodes])
+            node['child_labels'] = new_labels
+
     def add_nodes_to_tree(self, original, adds):
         """ Add all the nodes from new_nodes into the original tree. """
-        tree = tree_builder.build_tree_hash(original)
+        tree_hash = tree_builder.build_tree_hash(original)
+        for node in tree_hash.values():
+            self.set_child_labels(node)
 
         for label, node in adds.queue:
             p_label = '-'.join(tree_builder.parent_label(node))
-            if tree_builder.parent_in_tree(p_label, tree):
-                tree_builder.add_node_to_tree(node, p_label, tree)
+            if tree_builder.parent_in_tree(p_label, tree_hash):
+                tree_builder.add_node_to_tree(node, p_label, tree_hash)
                 adds.delete(label)
             else:
                 parent = adds.find(p_label)

--- a/regulations/tests/diff_applier_tests.py
+++ b/regulations/tests/diff_applier_tests.py
@@ -156,6 +156,44 @@ class DiffApplierTest(TestCase):
 
         da.add_nodes_to_tree(tree, adds)
 
+    def test_add_nodes_child_ops(self):
+        """If we don't know the correct order of children, attempt to use data
+        from `child_ops`"""
+        mk_node = lambda section: {
+            'label': ['100', section], 'node_type': 'regtext', 'children': []}
+        node_1, node_2 = mk_node('1'), mk_node('2')
+        node_2a, node_3 = mk_node('2a'), mk_node('3')
+        original = {'label': ['100'], 'node_type': 'regtext', 'children': [
+            node_1, node_2
+        ]}
+
+        diff = {
+            '100': {
+                'op': diff_applier.DiffApplier.MODIFIED_OP,
+                'child_ops': [[diff_applier.DiffApplier.EQUAL, 0, 1],
+                              [diff_applier.DiffApplier.DELETE, 1, 2],
+                              [diff_applier.DiffApplier.INSERT, 1, ['100-2a']],
+                              [diff_applier.DiffApplier.INSERT, 2, ['100-3']]]
+            },
+            '100-2': {'op': diff_applier.DiffApplier.DELETED_OP},
+            '100-2a': {
+                'op': diff_applier.DiffApplier.ADDED_OP,
+                'node': node_2a
+            },
+            '100-3': {
+                'op': diff_applier.DiffApplier.ADDED_OP,
+                'node': node_3
+            }
+        }
+
+        adds = tree_builder.AddQueue()
+        adds.insert_all([('100-2a', node_2a), ('100-3', node_3)])
+
+        da = diff_applier.DiffApplier(diff, None)
+        da.add_nodes_to_tree(original, adds)
+        self.assertEqual(original['child_labels'],
+                         ['100-1', '100-2', '100-2a', '100-3'])
+
     def test_child_picking(self):
         da = self.create_diff_applier()
         da.label_requested = '204-3'

--- a/regulations/tests/diff_applier_tests.py
+++ b/regulations/tests/diff_applier_tests.py
@@ -159,8 +159,9 @@ class DiffApplierTest(TestCase):
     def test_add_nodes_child_ops(self):
         """If we don't know the correct order of children, attempt to use data
         from `child_ops`"""
-        mk_node = lambda section: {
-            'label': ['100', section], 'node_type': 'regtext', 'children': []}
+        def mk_node(section):
+            return {'label': ['100', section], 'node_type': 'regtext',
+                    'children': []}
         node_1, node_2 = mk_node('1'), mk_node('2')
         node_2a, node_3 = mk_node('2a'), mk_node('3')
         original = {'label': ['100'], 'node_type': 'regtext', 'children': [


### PR DESCRIPTION
Assuming we find the correct data in the diff structure, we can properly order
the children of nodes in the diff section. Previously, we attempted to derive
a correct order by looking only at the labels. We'll be able to remove this
logic once all diff data is updated to contain the child_ops data.

See 18f/atf-eregs#123 for an explanation of how this fits into the rest of the plan.