### PR TITLE
Superscript formatting layer

### DIFF
--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -9,7 +9,7 @@ class FormattingLayer(object):
         self.tpls = {
             key: loader.get_template('regulations/layers/{}.html'.format(key))
             for key in ('table', 'note', 'code', 'subscript', 'dash',
-                        'footnote')}
+                        'footnote', 'superscript')}
 
     def render_table(self, table, data_type=None):
         max_width = 0
@@ -59,7 +59,8 @@ class FormattingLayer(object):
     def apply_layer(self, text_index):
         """Convert all plaintext tables into html tables"""
         layer_pairs = []
-        data_types = ['table', 'fence', 'subscript', 'dash', 'footnote']
+        data_types = ['table', 'fence', 'subscript', 'dash', 'footnote',
+                      'superscript']
         for data in self.layer_data.get(text_index, []):
             for data_type in data_types:
                 processor = getattr(self, 'render_' + data_type,

--- a/regulations/templates/regulations/layers/subscript.html
+++ b/regulations/templates/regulations/layers/subscript.html
@@ -1,4 +1,1 @@
-{% comment %}
-    Subscripts for text in appendices
-{% endcomment %}
-{{ variable }}<sub>{{ subscript }}</sub>
+<sub>{{ subscript }}</sub>

--- a/regulations/templates/regulations/layers/superscript.html
+++ b/regulations/templates/regulations/layers/superscript.html
@@ -1,0 +1,2 @@
+<sup>{{ superscript }}</sup>
+

--- a/regulations/tests/layers_formatting_tests.py
+++ b/regulations/tests/layers_formatting_tests.py
@@ -63,8 +63,12 @@ class FormattingLayerTest(TestCase):
         self.assert_context_contains('code', 'fence_data', data)
 
     def test_apply_layer_subscript(self):
-        data = {'variable': 'abc', 'subscript': '123'}
+        data = {'subscript': '123'}
         self.assert_context_contains('subscript', 'subscript_data', data)
+
+    def test_apply_layer_superscript(self):
+        data = {'superscript': '123'}
+        self.assert_context_contains('superscript', 'superscript_data', data)
 
     def test_apply_layer_dash(self):
         data = {'text': 'This is an fp-dash'}


### PR DESCRIPTION
Create `<sup>`s if the data's present. Also removes the `variable` field from
subscripts, as it's no longer used.

Looks like
<img width="572" alt="screen shot 2015-12-09 at 12 06 44 pm" src="https://cloud.githubusercontent.com/assets/326918/11692454/87512e9c-9e6d-11e5-8f86-2d021c3f5150.png">

For 18f/atf-eregs#155