### PR TITLE
Fix back button to landing page

### DIFF
--- a/regulations/static/regulations/js/source/router.js
+++ b/regulations/static/regulations/js/source/router.js
@@ -21,7 +21,9 @@ else {
             'sxs/:section/:version': 'loadSxS',
             'search/:reg': 'loadSearchResults',
             'diff/:section/:baseVersion/:newerVersion': 'loadDiffSection',
-            ':section/:version': 'loadSection'
+            ':section/:version': 'loadSection',
+            ':section': 'loadSection'
+
         },
         loadSection: function(section) {
             var options = {id: section};

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -38,6 +38,7 @@ var MainView = Backbone.View.extend({
 
         var childViewOptions = {},
             appendixOrSupplement;
+
         this.$topSection = this.$el.find('section[data-page-type]');
 
         // which page are we starting on?
@@ -95,6 +96,7 @@ var MainView = Backbone.View.extend({
 
     modelmap: {
         'reg-section': RegModel,
+        'landing-page': RegModel,
         'search-results': SearchModel,
         'diff': DiffModel,
         'appendix': RegModel,
@@ -103,6 +105,7 @@ var MainView = Backbone.View.extend({
 
     viewmap: {
         'reg-section': RegView,
+        'landing-page': RegView,
         'search-results': SearchResultsView,
         'diff': DiffView,
         'appendix': RegView,

--- a/regulations/templates/regulations/generic_landing.html
+++ b/regulations/templates/regulations/generic_landing.html
@@ -1,6 +1,6 @@
 <div id="content-body" class="main-content">
     <section id="content-wrapper">
-        <section data-base-version="{{ current_version.version }}" class="landing" data-page-type="landing-page" data-reg-part="{{reg_part}}">
+        <section data-base-version="{{ current_version.version }}" class="landing" data-page-type="landing-page" data-reg-part="{{reg_part}}" id="{{reg_part}}">
             {% block reg_title %}
             {% endblock %}
 


### PR DESCRIPTION
Treat the regulation landing page in the same fashion as a section to facilitate caching of content.  