### PR TITLE
Begin to modularize layer data by adding a setting

### DIFF
--- a/regulations/generator/layers/analyses.py
+++ b/regulations/generator/layers/analyses.py
@@ -1,7 +1,7 @@
 from itertools import takewhile
 
-from regulations.generator.node_types import label_to_text
 from regulations.generator.layers.tree_builder import make_label_sortable
+from regulations.generator.node_types import label_to_text
 
 
 def sort_regtext_label(label):
@@ -39,9 +39,8 @@ def sort_analyses(analyses):
         return sorted_analyses
 
 
+# This is unlike other layers in that it is only used in the right sidebar
 class SectionBySectionLayer(object):
-    shorthand = 'sxs'
-
     def __init__(self, layer):
         self.layer = layer
         # Perform the computations we'll use when applying the layer only once

--- a/regulations/generator/layers/base.py
+++ b/regulations/generator/layers/base.py
@@ -1,0 +1,32 @@
+import abc
+
+
+class LayerBase(object):
+    """Base class for most layers; each layer contains information which is
+    added on top of the regulation, such as definitions, internal citations,
+    keyterms, etc."""
+    __metaclass__ = abc.ABCMeta
+
+    # @see layer_type
+    INLINE = 'inline'
+    PARAGRAPH = 'paragraph'
+    SEARCH_REPLACE = 'search_replace'
+
+    @abc.abstractproperty
+    def shorthand(self):
+        """A short description for this layer. This is used in query strings
+        and the like to define which layers should be used"""
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def data_source(self):
+        """Data is pulled from the API; this field indicates the name of the
+        endpoint to pull data from"""
+        raise NotImplementedError
+
+    @abc.abstractproperty
+    def layer_type(self):
+        """Layer data can be applied in a few ways, attaching itself to a
+        node, replacing text based on offset, or replacing text based on
+        searching. Which type is this layer?"""
+        raise NotImplementedError

--- a/regulations/generator/layers/defined.py
+++ b/regulations/generator/layers/defined.py
@@ -1,8 +1,12 @@
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 
-class DefinedLayer(object):
+
+class DefinedLayer(LayerBase):
     shorthand = 'defined'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/definitions.py
+++ b/regulations/generator/layers/definitions.py
@@ -1,12 +1,15 @@
 from django.template import loader
 
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 from ..node_types import to_markup_id
 import utils
 
 
-class DefinitionsLayer(object):
+class DefinitionsLayer(LayerBase):
     shorthand = 'terms'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/external_citation.py
+++ b/regulations/generator/layers/external_citation.py
@@ -2,9 +2,13 @@ import urllib
 from django.template import loader
 import utils
 
+from regulations.generator.layers.base import LayerBase
 
-class ExternalCitationLayer():
+
+class ExternalCitationLayer(LayerBase):
     shorthand = 'external'
+    data_source = 'terms'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/formatting.py
+++ b/regulations/generator/layers/formatting.py
@@ -1,8 +1,12 @@
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 
-class FormattingLayer(object):
+
+class FormattingLayer(LayerBase):
     shorthand = 'formatting'
+    data_source = 'formatting'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer_data):
         self.layer_data = layer_data

--- a/regulations/generator/layers/graphics.py
+++ b/regulations/generator/layers/graphics.py
@@ -1,9 +1,13 @@
 from django.template import loader
 import utils
 
+from regulations.generator.layers.base import LayerBase
 
-class GraphicsLayer(object):
+
+class GraphicsLayer(LayerBase):
     shorthand = 'graphics'
+    data_source = 'graphics'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer_data):
         self.layer_data = layer_data

--- a/regulations/generator/layers/internal_citation.py
+++ b/regulations/generator/layers/internal_citation.py
@@ -1,10 +1,13 @@
 from django.template import loader, Context
 
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 
 
-class InternalCitationLayer():
+class InternalCitationLayer(LayerBase):
     shorthand = 'internal'
+    data_source = 'internal-citations'
+    layer_type = LayerBase.INLINE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/interpretations.py
+++ b/regulations/generator/layers/interpretations.py
@@ -2,13 +2,16 @@ from django.http import HttpRequest
 
 #   Don't import PartialInterpView or utils directly; causes an import cycle
 from regulations import generator, views
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.node_types import label_to_text
 from regulations.generator.section_url import SectionUrl
 
 
-class InterpretationsLayer(object):
+class InterpretationsLayer(LayerBase):
     """Fetches the (rendered) interpretation for this node, if available"""
     shorthand = 'interp'
+    data_source = 'interpretations'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer, version=None):
         self.layer = layer

--- a/regulations/generator/layers/key_terms.py
+++ b/regulations/generator/layers/key_terms.py
@@ -2,9 +2,13 @@ import string
 import utils
 from django.template import loader
 
+from regulations.generator.layers.base import LayerBase
 
-class KeyTermsLayer(object):
+
+class KeyTermsLayer(LayerBase):
     shorthand = 'keyterms'
+    data_source = 'keyterms'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/meta.py
+++ b/regulations/generator/layers/meta.py
@@ -1,8 +1,11 @@
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.layers.utils import convert_to_python
 
 
-class MetaLayer(object):
+class MetaLayer(LayerBase):
     shorthand = 'meta'
+    data_source = 'meta'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer_data):
         self.layer_data = convert_to_python(layer_data)

--- a/regulations/generator/layers/paragraph_markers.py
+++ b/regulations/generator/layers/paragraph_markers.py
@@ -1,9 +1,13 @@
 from django.template import loader
 import utils
 
+from regulations.generator.layers.base import LayerBase
 
-class ParagraphMarkersLayer(object):
+
+class ParagraphMarkersLayer(LayerBase):
     shorthand = 'paragraph'
+    data_source = 'paragraph-markers'
+    layer_type = LayerBase.SEARCH_REPLACE
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/generator/layers/toc_applier.py
+++ b/regulations/generator/layers/toc_applier.py
@@ -1,12 +1,15 @@
 # vim: set fileencoding=utf-8
 from regulations.generator import title_parsing
+from regulations.generator.layers.base import LayerBase
 from regulations.generator.section_url import SectionUrl
 from regulations.generator.toc import (
     toc_interp, toc_sect_appendix, toc_subpart)
 
 
-class TableOfContentsLayer(object):
+class TableOfContentsLayer(LayerBase):
     shorthand = 'toc'
+    data_source = 'toc'
+    layer_type = LayerBase.PARAGRAPH
 
     def __init__(self, layer):
         self.layer = layer

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -204,3 +204,21 @@ LOGGING = {
         },
     }
 }
+
+
+# Where should we look for data?
+DATA_LAYERS = (
+    'regulations.generator.layers.defined.DefinedLayer',
+    'regulations.generator.layers.definitions.DefinitionsLayer',
+    # Commented out of the defaults until the feature is considered complete
+    # 'regulations.generator.layers.external_citation.ExternalCitationLayer',
+    'regulations.generator.layers.formatting.FormattingLayer',
+    'regulations.generator.layers.internal_citation.InternalCitationLayer',
+    # Should likely be moved to a CFPB-specific module
+    'regulations.generator.layers.interpretations.InterpretationsLayer',
+    'regulations.generator.layers.key_terms.KeyTermsLayer',
+    'regulations.generator.layers.meta.MetaLayer',
+    'regulations.generator.layers.paragraph_markers.ParagraphMarkersLayer',
+    'regulations.generator.layers.toc_applier.TableOfContentsLayer',
+    'regulations.generator.layers.graphics.GraphicsLayer',
+)

--- a/regulations/tests/generator_tests.py
+++ b/regulations/tests/generator_tests.py
@@ -88,12 +88,6 @@ class GeneratorTest(TestCase):
             ('204', 'old', 'new'),
             get_diff_json.call_args[0])
 
-    def test_layercreator_layers(self):
-        """ A LAYER entry must have three pieces of information specified. """
-
-        for l, v in generator.LayerCreator.LAYERS.items():
-            self.assertEqual(len(v), 3)
-
     def test_layercreator_getappliers(self):
         creator = generator.LayerCreator()
         appliers = creator.get_appliers()


### PR DESCRIPTION
Previously, the mega `generator` module knew about most of the different types
of layers. It created a big dictionary of them for iterating through. This
patch moves that listing into a settings file so that it can be replaced by
different clients. Further, it moves data related to where the layer
information comes from and how it should be applied into the individual layer
classes; it also introduces a few constants and creates a common abstract base
class for most layers.

This does _not_ make the section-by-section analyses on the right hand side
configurable; they are currently hard coded into the sidebar view.

Part of 18f/atf-eregs#116