### PR TITLE
set background color on thead 

### DIFF
--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -583,7 +583,7 @@ th {
 }
 
 thead {
-    background-color: #eee;
+    background-color: #fff;
 }
 
 .table-wrap {

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -582,6 +582,10 @@ th {
     text-align: left;
 }
 
+thead {
+    background-color: #eee;
+}
+
 .table-wrap {
     overflow-x: auto;
     -webkit-overflow-scrolling: touch; // smoother scrolling        


### PR DESCRIPTION
Scrolling table data remains visible as it scrolls by the table headers if there is no background present.