### PR TITLE
Remote li markers from Notes

### DIFF
--- a/regulations/static/regulations/css/less/module/interpretations.less
+++ b/regulations/static/regulations/css/less/module/interpretations.less
@@ -140,6 +140,7 @@
         font-size: 0.875em;
         padding: 0;
         margin: 0;
+        list-style: none;
     }
 
     li {


### PR DESCRIPTION
Previously, we had assumed Notes would only exist in the appendix, where _all_
li markers are missing. Now that we're including them in the regtext, we must
make the list-style explicit.

![original](https://cloud.githubusercontent.com/assets/326918/11478243/cbf83aec-9759-11e5-8431-6b103432248e.png)
<img width="531" alt="screen shot 2015-12-16 at 11 43 06 am" src="https://cloud.githubusercontent.com/assets/326918/11847154/0e65a616-a3ea-11e5-8508-d133afbea987.png">

Resolves 18f/atf-eregs#134