### PR TITLE
Define behavior when nodes are re-ordered

### DIFF
--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -76,7 +76,8 @@ class DiffApplier(object):
             counts[label_op.label] += 1
 
         return [label_op for label_op in label_ops
-                if counts[label_op.label] == 1 or label_op.op == 'insert']
+                if counts[label_op.label] == 1
+                or label_op.op == DiffApplier.INSERT]
 
     def add_nodes_to_tree(self, original, adds):
         """ Add all the nodes from new_nodes into the original tree. """

--- a/regulations/generator/layers/diff_applier.py
+++ b/regulations/generator/layers/diff_applier.py
@@ -1,6 +1,6 @@
 import types
 import copy
-from collections import deque
+from collections import defaultdict, deque, namedtuple
 
 from regulations.generator.layers import tree_builder
 
@@ -49,6 +49,8 @@ class DiffApplier(object):
         """ Mark all the text passed in as deleted. """
         return '<ins>' + text + '</ins>'
 
+    _LabelOp = namedtuple('LabelOp', ['label', 'op'])
+
     def set_child_labels(self, node):
         """As we display removed, added, and unchanged nodes, the children of
         a node will contain all three types. Pull the 'child_ops' data to
@@ -56,13 +58,25 @@ class DiffApplier(object):
         instructs = self.diff.get('-'.join(node['label']), {})
         if 'child_labels' not in instructs and 'child_ops' in instructs:
             original_labels = ['-'.join(c['label']) for c in node['children']]
-            new_labels = []
-            for op, start, end_or_nodes in instructs['child_ops']:
-                if isinstance(end_or_nodes, list):
-                    new_labels.extend(end_or_nodes)
+            label_ops = []
+            for op, start, end_or_labels in instructs['child_ops']:
+                if isinstance(end_or_labels, list):
+                    labels = end_or_labels
                 else:
-                    new_labels.extend(original_labels[start:end_or_nodes])
-            node['child_labels'] = new_labels
+                    labels = original_labels[start:end_or_labels]
+                label_ops.extend(DiffApplier._LabelOp(l, op) for l in labels)
+            label_ops = self.remove_moved_labels(label_ops)
+            node['child_labels'] = [lo.label for lo in label_ops]
+
+    def remove_moved_labels(self, label_ops):
+        """If a label has been moved, meaning deleted in one position, but
+        added in another, we will display it in the second position"""
+        counts = defaultdict(int)
+        for label_op in label_ops:
+            counts[label_op.label] += 1
+
+        return [label_op for label_op in label_ops
+                if counts[label_op.label] == 1 or label_op.op == 'insert']
 
     def add_nodes_to_tree(self, original, adds):
         """ Add all the nodes from new_nodes into the original tree. """

--- a/regulations/generator/layers/tree_builder.py
+++ b/regulations/generator/layers/tree_builder.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 
 
 class AddQueue(object):
@@ -165,6 +166,8 @@ def add_child(parent_node, node):
             lookup['-'.join(c['label'])] = c
         parent_node['children'] = [lookup[label_id] for label_id in order]
     else:   # Explicit sort order not present/doesn't match nodes
+        logging.warning(
+            "No child_labels field. Guessing at child order (probably wrong)")
         for c in parent_node['children']:
             if c['node_type'].upper() == 'INTERP':
                 if c['label'][-1] == 'Interp':

--- a/regulations/tests/diff_applier_tests.py
+++ b/regulations/tests/diff_applier_tests.py
@@ -195,6 +195,24 @@ class DiffApplierTest(TestCase):
         self.assertEqual(original['child_labels'],
                          ['100-1', '100-2', '100-2a', '100-3'])
 
+    def test_set_child_labels_reorder(self):
+        """Nodes which have been _moved_ should be ordered in their final
+        resting position"""
+        node1 = {'label': ['1', '1'], 'node_type': 'regtext', 'children': []}
+        node2 = {'label': ['1', '2'], 'node_type': 'regtext', 'children': []}
+        root = {'label': ['1'], 'node_type': 'regtext',
+                'children': [node1, node2]}
+
+        diff = {'1': {
+            'op': diff_applier.DiffApplier.MODIFIED_OP,
+            'child_ops': [[diff_applier.DiffApplier.DELETE, 0, 2],
+                          [diff_applier.DiffApplier.INSERT, 0, ['1-2', '1-1']]]
+        }}
+
+        da = diff_applier.DiffApplier(diff, None)
+        da.set_child_labels(root)
+        self.assertEqual(root['child_labels'], ['1-2', '1-1'])
+
     def test_child_picking(self):
         da = self.create_diff_applier()
         da.label_requested = '204-3'


### PR DESCRIPTION
Previously, when a node was re-ordered within its parent, the UI would see the
same node as being present in two locations (where it had been deleted from
and where it was added to). This would silent fail the diff ordering process,
which would then re-order all of the children using a best-guess heuristic.

This patch defines behavior for such a change, placing the node in its final
position when displaying the diff.

Supports (but does not resolve) 18f/atf-eregs#206