### PR TITLE
Allow node-specific custom markup

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@ rules:
   no-cond-assign: 0
   no-comma-dangle: 2
   no-console: 1
-  no-extra-parens: 2
+  # no-extra-parens: 2
   no-irregular-whitespace: 2
   no-reserved-keys: 2
 
@@ -28,7 +28,7 @@ rules:
   curly: 2
   no-alert: 2
   no-eval: 2
-  no-extend-native: 2
+  # no-extend-native: 2
   no-with: 2
 
   # Variables
@@ -43,21 +43,21 @@ rules:
 
 
   # Stylistic issues
-  brace-style: 2
+  # brace-style: 2
   camelcase: 0
   new-cap: 0
   no-mixed-spaces-and-tabs: 2
-  no-lonely-if: 2
+  # no-lonely-if: 2
   no-space-before-semi: 2
   no-underscore-dangle: 0
   space-after-keywords: 2
   no-trailing-spaces: 2
   space-in-brackets: [2, never]
-  space-infix-ops: 2
+  # space-infix-ops: 2
   quotes: [2, single]
   semi: [2, "always"]
 
-  # Outstanding issues
+  # Outstanding issues. Correct values commented out above
   no-unused-vars: 0
   no-extend-native: 0
   valid-typeof: 0

--- a/README.md
+++ b/README.md
@@ -256,6 +256,6 @@ To use this override mechanism, create a `templates/regulations/custom_nodes`
 directory in your Django application if it doesn't already exist. Inside that
 folder, create files corresponding to node labels, e.g. `478-103-b.html`.
 These templates will be used **in place** of the `tree-with-wrapper.html`
-template, so be sure to provide the functionality alreay present there. Should
-you need to use this functionality only on specific versions, your template
-can make use of the `version` context variable.
+template, so be sure to provide the functionality already present there.
+Should you need to use this functionality only on specific versions, your
+template can make use of the `version` context variable.

--- a/README.md
+++ b/README.md
@@ -222,3 +222,21 @@ After you create a [Sauce Labs](https://saucelabs.com) account:
 - Unit tests do not require running the dummy API.
 - To run the unit tests along with the functional tests: ```grunt test``` from the root of the repo.
 - To run unit tests individually: ```grunt mocha_istanbul``` from the root of the repo.
+
+## Customization
+
+Note that this section is incomplete
+
+### Individual Paragraphs
+
+The templates used to generate paragraphs can be replaced selectively, a
+useful technique if you want to emphasize a particular paragraph or add links
+to external sources that don't exist in the regulation proper. Note that this
+mechanism is intended for one-offs; consider method of modifying the data
+structures instead if you find yourself using it often.
+
+To use this override mechanism, create a `templates/regulations/custom_nodes`
+directory in your Django application if it doesn't already exist. Inside that
+folder, create files corresponding to node labels, e.g. `478-103-b.html`.
+These templates will be used **in place** of the `tree-with-wrapper.html`
+template, so be sure to provide the functionality alreay present there.

--- a/README.md
+++ b/README.md
@@ -239,4 +239,6 @@ To use this override mechanism, create a `templates/regulations/custom_nodes`
 directory in your Django application if it doesn't already exist. Inside that
 folder, create files corresponding to node labels, e.g. `478-103-b.html`.
 These templates will be used **in place** of the `tree-with-wrapper.html`
-template, so be sure to provide the functionality alreay present there.
+template, so be sure to provide the functionality alreay present there. Should
+you need to use this functionality only on specific versions, your template
+can make use of the `version` context variable.

--- a/regulations/apps.py
+++ b/regulations/apps.py
@@ -1,0 +1,34 @@
+from collections import defaultdict
+import os
+
+from django.apps import AppConfig
+from django.template.loaders.app_directories import get_app_template_dirs
+
+
+class RegulationsConfig(AppConfig):
+    name = 'regulations'
+    # Maps node label_id's to the template which should be used to render
+    # them. Warning: global state
+    precomputed_templates = defaultdict(
+        lambda: "regulations/tree-with-wrapper.html")
+
+    def ready(self):
+        """Called (almost) once per application startup. Should only contain
+        idempotent operations"""
+        self.precompute_custom_templates()
+
+    @staticmethod
+    def precompute_custom_templates():
+        """We allow agencies to provide templates for specific nodes in the
+        regulation tree. Rather than have the rendering code inspect which
+        templates are available at render time, we'll find the special cases
+        during the application startup"""
+        search_path = os.path.join('templates', 'regulations', 'custom_nodes')
+        file_names = {file_name
+                      for template_dir in get_app_template_dirs(search_path)
+                      for file_name in os.listdir(template_dir)
+                      if os.path.isfile(os.path.join(template_dir, file_name))}
+        for file_name in file_names:
+            ident, _ = os.path.splitext(file_name)
+            RegulationsConfig.precomputed_templates[ident] = (
+                'regulations/custom_nodes/' + file_name)

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -107,7 +107,7 @@ class HTMLBuilder():
         node = self.p_applier.apply_layers(node)
 
         node['template_name'] = RegulationsConfig.precomputed_templates[
-            node['markup_id']]
+            node['label_id']]
 
         if 'TOC' in node:
             for l in node['TOC']:

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -7,6 +7,7 @@ from itertools import ifilter, ifilterfalse, takewhile
 from node_types import to_markup_id, APPENDIX, INTERP
 from layers.layers_applier import LayersApplier
 from layers.internal_citation import InternalCitationLayer
+from regulations.apps import RegulationsConfig
 
 
 class HTMLBuilder():
@@ -65,9 +66,14 @@ class HTMLBuilder():
                 node['header'] = self.diff_applier.apply_diff(
                     node['header'], node['label_id'], component='title')
 
-            node['header'] = HTMLBuilder.section_space(node['header'])
+            node['header'] = self.section_space(node['header'])
 
     def process_node(self, node):
+        """Every node passes through this function on the way to being
+        rendered. Importantly, this adds the `marked_up` field, which contains
+        the HTML version of node's text (after applying all relevant
+        layers) and the `template_name` field, which defines how this node
+        should be rendered."""
 
         node['label_id'] = '-'.join(node['label'])
         self.process_node_title(node)
@@ -94,21 +100,21 @@ class HTMLBuilder():
             layers_applier.enqueue_from_list(inline_elements)
             layers_applier.enqueue_from_list(search_elements)
 
-            if 'marked_up' in node:
-                node['marked_up'] = layers_applier.apply_layers(
-                    node['marked_up'])
-            else:
-                node['marked_up'] = layers_applier.apply_layers(node['text'])
-            node['marked_up'] = HTMLBuilder.section_space(node['marked_up'])
+            node['marked_up'] = layers_applier.apply_layers(
+                node.get('marked_up', node['text']))
+            node['marked_up'] = self.section_space(node['marked_up'])
 
         node = self.p_applier.apply_layers(node)
 
+        node['template_name'] = RegulationsConfig.precomputed_templates[
+            node['markup_id']]
+
         if 'TOC' in node:
             for l in node['TOC']:
-                l['label'] = HTMLBuilder.section_space(l['label'])
+                l['label'] = self.section_space(l['label'])
 
         if 'interp' in node and 'markup' in node['interp']:
-            node['interp']['markup'] = HTMLBuilder.section_space(
+            node['interp']['markup'] = self.section_space(
                 node['interp']['markup'])
 
         if node['node_type'] == INTERP:

--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -116,7 +116,7 @@ ROOT_URLCONF = 'regulations.urls'
 
 INSTALLED_APPS = (
     'django.contrib.staticfiles',
-    'regulations',
+    'regulations.apps.RegulationsConfig',
 )
 
 # eregs specific settings

--- a/regulations/templates/regulations/appendix.html
+++ b/regulations/templates/regulations/appendix.html
@@ -29,7 +29,7 @@
                 {% include "regulations/ol-tag.html" %}
                 {% endwith %}
                 {% for node in level_one.children  %}
-                    {% include "regulations/tree-with-wrapper.html" %}
+                    {% include node.template_name %}
                 {% endfor %}
                 </ol>
             {% endif %}

--- a/regulations/templates/regulations/interp-tree.html
+++ b/regulations/templates/regulations/interp-tree.html
@@ -22,7 +22,7 @@
         {% endwith %}
             {% for par_child in interp.par_children %}
                 {% with node=par_child %}
-                    {% include "regulations/tree-with-wrapper.html" %}
+                    {% include node.template_name %}
                 {% endwith %}
             {% endfor %}
         </ol>

--- a/regulations/templates/regulations/regulation_text.html
+++ b/regulations/templates/regulations/regulation_text.html
@@ -16,7 +16,7 @@
         {% endwith %}
         {% if c.children %}
             {% for node in c.children %}
-                {% include "regulations/tree-with-wrapper.html"  %}
+              {% include node.template_name %}
             {% endfor %}
         {% endif %}
         </ol>

--- a/regulations/templates/regulations/tree.html
+++ b/regulations/templates/regulations/tree.html
@@ -19,8 +19,8 @@
     {% include "regulations/ol-tag.html" %}
     {% endwith %}
     {% for c in node.children %}
-        {%with node=c template_name="regulations/tree-with-wrapper.html" %}
-            {% include template_name %}
+        {% with node=c %}
+            {% include node.template_name %}
         {% endwith %}
     {% endfor %}
 </ol>

--- a/regulations/tests/apps_tests.py
+++ b/regulations/tests/apps_tests.py
@@ -1,0 +1,32 @@
+import os
+import shutil
+import tempfile
+from unittest import TestCase
+
+from mock import patch
+
+from regulations.apps import RegulationsConfig
+
+
+class RegulationsConfigTests(TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    @patch('regulations.apps.get_app_template_dirs')
+    def test_precompute_custom_templates(self, get_app_template_dirs):
+        """Verify that custom templates are found and that a default dict is
+        used"""
+        get_app_template_dirs.return_value = [self.tmpdir]
+        open(os.path.join(self.tmpdir, '123-45-a.html'), 'w').close()
+        open(os.path.join(self.tmpdir, 'other.html'), 'w').close()
+
+        RegulationsConfig.precompute_custom_templates()
+        self.assertEqual(RegulationsConfig.precomputed_templates['123-45-a'],
+                         'regulations/custom_nodes/123-45-a.html')
+        self.assertEqual(RegulationsConfig.precomputed_templates['other'],
+                         'regulations/custom_nodes/other.html')
+        self.assertEqual(RegulationsConfig.precomputed_templates['a_default'],
+                         'regulations/tree-with-wrapper.html')


### PR DESCRIPTION
See individual changesets for more details, but the gist is that this patch tells the UI to look for node-specific template overrides. For example, this allowed me to hack together:

```
(atf-site)vagrant@debian8:~/atf-eregs$ cat atf_eregs/templates/regulations/custom_nodes/478-103-b.html
{% comment %}
    Replaces the tree-with-wrapper.html and tree.html templates, providing
    some PDF-specific links
{% endcomment %}
<li id="478-103-b" data-permalink-section>
  <p>{{ node.marked_up|safe }}</p>

  <div style="border: dashed red 2px;">
    <p>The standard notification described in this paragraph can be downloaded
    here: <a href="http://example.com" class="external">ATF I 5300.2</a></p>
  </div>

  {% with first_child=node.children|first %}
    {% include "regulations/ol-tag.html" %}
  {% endwith %}
  {% for c in node.children %}
    {% with node=c %}
      {% include node.template_name %}
    {% endwith %}
  {% endfor %}
  </ol>
</li>
```
<img width="692" alt="screen shot 2016-01-06 at 12 16 46 pm" src="https://cloud.githubusercontent.com/assets/326918/12149167/3441d6fc-b470-11e5-9341-acc46cf9653f.png">

Part of 18f/atf-eregs#224