### PR TITLE
Paragraph markers in CSS + "custom" LESS hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,24 @@ After you create a [Sauce Labs](https://saucelabs.com) account:
 - Unit tests do not require running the dummy API.
 - To run the unit tests along with the functional tests: ```grunt test``` from the root of the repo.
 - To run unit tests individually: ```grunt mocha_istanbul``` from the root of the repo.
+
+## Customization
+
+Note that this section is incomplete
+
+### System-wide Styles
+
+The `compile_frontend` command (i.e. `python manage.py. compile_frontend`)
+uses a variant of Django's `collectstatic` to combine static assets between
+the base application (regulations-site) and any custom Django application you
+develop. It is designed as a simple file **override** scheme -- create an
+identically named file in your `static/regulations/` directory and it will
+replace the file in the base application. In this way, you can modify
+stylesheets, images, etc. when building the frontend.
+
+There is also a key extension point for stylesheets:
+`static/regulations/css/less/module/custom.less` exists to be overridden. Use
+it to declare your own custom style sheet modules for additional structure.
+
+The `compile_frontend` command generates output indicating which files are
+being overridden.

--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -67,10 +67,22 @@ class HTMLBuilder():
 
             node['header'] = HTMLBuilder.section_space(node['header'])
 
+    @staticmethod
+    def is_collapsed(node):
+        """A "collapsed" paragraph is one which has no text, immediately
+        starting a subparagraph. For example:
+        (a)(1) Some text    <- (a) is collapsed
+        (a) Some text - (1) Other text   <- (a) is not collapsed
+        """
+        marker = '({})'.format(node['label'][-1])
+        text_without_marker = node['text'].replace(marker, '')
+        return not text_without_marker.strip()
+
     def process_node(self, node):
 
         node['label_id'] = '-'.join(node['label'])
         self.process_node_title(node)
+        node['is_collapsed'] = self.is_collapsed(node)
 
         node['html_label'] = to_markup_id(node['label'])
         node['markup_id'] = "-".join(node['html_label'])

--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -35,6 +35,7 @@ Modules
 @import "module/about.less";
 @import "module/error.less";
 @import "module/paragraph-markers.less";
+@import "module/custom.less";
 
 
 /*

--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -34,6 +34,7 @@ Modules
 @import "module/universal-landing.less";
 @import "module/about.less";
 @import "module/error.less";
+@import "module/paragraph-markers.less";
 
 
 /*

--- a/regulations/static/regulations/css/less/module/custom.less
+++ b/regulations/static/regulations/css/less/module/custom.less
@@ -1,0 +1,1 @@
+/* Placeholder for agency-specific modules (i.e. features) */

--- a/regulations/static/regulations/css/less/module/paragraph-markers.less
+++ b/regulations/static/regulations/css/less/module/paragraph-markers.less
@@ -1,0 +1,25 @@
+ol, li {
+  &.lower {
+    list-style-type: lower-alpha;
+  }
+
+  &.upper {
+    list-style-type: upper-alpha;
+  }
+
+  &.roman {
+    list-style-type: lower-roman;
+  }
+
+  &.upper-roman {
+    list-style-type: upper-roman;
+  }
+
+  &.int {
+    list-style-type: decimal;
+  }
+
+  &.markerless {
+    list-style-type: none;
+  }
+}

--- a/regulations/static/regulations/css/less/module/paragraph-markers.less
+++ b/regulations/static/regulations/css/less/module/paragraph-markers.less
@@ -23,3 +23,13 @@ ol, li {
     list-style-type: none;
   }
 }
+
+ol.level-1 {  /* the beginning a reg paragraphs */
+  li {
+    position: relative;
+  }
+
+  .collapsed {
+    position: absolute;
+  }
+}

--- a/regulations/templates/regulations/layers/paragraph_markers.html
+++ b/regulations/templates/regulations/layers/paragraph_markers.html
@@ -1,4 +1,4 @@
 {% comment %}
     Can be thought of as the list bullet for each paragraph
 {% endcomment %}
-<span class="stripped-marker">{{ paragraph_stripped }}.</span><em class="paragraph-marker">{{ paragraph }}</em>
+<span class="stripped-marker">{{ paragraph_stripped }}.</span><span class="paragraph-marker">{{ paragraph }}</span>

--- a/regulations/templates/regulations/ol-tag.html
+++ b/regulations/templates/regulations/ol-tag.html
@@ -5,16 +5,12 @@
     Expects a `first_child` variable
 {% endcomment %}
 {% with m=first_child.label|last %}
-    {% comment %}
-        Note that there isn't a built-in inclusion check in django, so
-        spelling it out with `or`s.
-    {% endcomment %}
-    {% if m == 'a' or m == 'A' or m == 'i' or m == 'I' or m == '1' %}
-        <ol class="level-{{first_child.list_level}}" type="{{m}}"
-                                                     extra="{{first_child.label}}">
-    {% else %}
-        <ol class="level-{{first_child.list_level}}"
-            {% comment %}TODO: Move into stylesheet{% endcomment %}
-            style="list-style: none;">
-    {% endif %}
+    <ol class="level-{{first_child.list_level}}
+               {% if m == 'a' %}lower
+               {% elif m == 'A' %}upper
+               {% elif m == 'i' %}roman
+               {% elif m == 'I' %}upper-roman
+               {% elif m == '1' %}int
+               {% else %}markerless
+               {% endif %}">
 {% endwith %}

--- a/regulations/templates/regulations/tree.html
+++ b/regulations/templates/regulations/tree.html
@@ -6,7 +6,7 @@
 {% endif %}
 
 {%if node.marked_up %}
-<p> 
+<p {% if node.is_collapsed %}class="collapsed"{% endif %}>
 {% if node.node_type == "appendix" %}
     {{node.marked_up|safe|linebreaksbr}}
 {% else  %}

--- a/regulations/tests/html_builder_test.py
+++ b/regulations/tests/html_builder_test.py
@@ -276,3 +276,15 @@ class HTMLBuilderTest(TestCase):
         self.assertTrue(exex.preprocess_root.called)
         self.assertEqual(exex.preprocess_root.call_args[0][0],
                          builder.tree)
+
+    def test_is_collapsed(self):
+        for label, text in ((['111', '22', 'a'], '(a) '),
+                            (['111', '22', 'xx'], ' (xx) '),
+                            (['111', '22', 'a', '5'], '(5)')):
+            node = {'label': label, 'text': text}
+            self.assertTrue(HTMLBuilder.is_collapsed(node))
+
+        for label, text in ((['111', '22', 'a'], '(b) '),
+                            (['111', '22', ''], '(a) Some text')):
+            node = {'label': label, 'text': text}
+            self.assertFalse(HTMLBuilder.is_collapsed(node))


### PR DESCRIPTION
We have been relying on the markup to tell the browser which marker type to
use. Aside from an inline style, this worked fine, but we're reaching
situations where a containing div needs the ability to override the markers of
its contents. Enter CSS.

Also swapped an `em` for `span` when rendering the paragraph marker. This
element hasn't ever been displayed (though we'll start soon); it shouldn't
have ever been an `em`

Also removes an `extra` attribute on `ol`s. This shouldn't have ever been
present -- it's unused and renders unnecessary content.

And:
Adds and documents a LESS file whose sole purpose is to be overridden by
agency-specific styles.

And:
We've relied on some intelligent style sheet magic to implement collapsed
markers (where a paragraph and its subparagraph are displayed on the same
line, visually) but that only works when using the list-style marker generated
by the browser. As we'll need to use markers from the text at multiple points
in the near future, this patch explicitly tags collapsed paragraphs when
rendering the markup.

Work towards 18f/atf-eregs#224