### PR TITLE
Removed negative margin / border

### DIFF
--- a/regulations/static/regulations/css/less/layout.less
+++ b/regulations/static/regulations/css/less/layout.less
@@ -249,8 +249,6 @@ Section Offsets
     .reg-section .level-1 li,
     .appendix-section .level-1 li,
     .supplement-section .level-1 li {
-        border-top: 100px solid transparent;
-        margin-top: -100px;
         -webkit-background-clip:padding-box;
         -moz-background-clip:padding;
         background-clip:padding-box;


### PR DESCRIPTION
The negative margin clobbers scrollbars in above content rendering them unusable.  Not sure what this accomplished in the first place.

@theresaanna - can you offer any insight into why this is here?