### PR TITLE
Don't use relative for lis

### DIFF
--- a/regulations/generator/html_builder.py
+++ b/regulations/generator/html_builder.py
@@ -76,7 +76,7 @@ class HTMLBuilder():
         """
         marker = '({})'.format(node['label'][-1])
         text_without_marker = node['text'].replace(marker, '')
-        return not text_without_marker.strip()
+        return node['text'].strip() and not text_without_marker.strip()
 
     def process_node(self, node):
 

--- a/regulations/static/regulations/css/less/module/paragraph-markers.less
+++ b/regulations/static/regulations/css/less/module/paragraph-markers.less
@@ -22,14 +22,10 @@ ol, li {
   &.markerless {
     list-style-type: none;
   }
-}
 
-ol.level-1 {  /* the beginning a reg paragraphs */
-  li {
-    position: relative;
-  }
-
+  /* Paragraphs without content. We may want to display their paragraph marker */
   .collapsed {
-    position: absolute;
+    float: left;
   }
 }
+

--- a/regulations/tests/html_builder_test.py
+++ b/regulations/tests/html_builder_test.py
@@ -285,6 +285,7 @@ class HTMLBuilderTest(TestCase):
             self.assertTrue(HTMLBuilder.is_collapsed(node))
 
         for label, text in ((['111', '22', 'a'], '(b) '),
-                            (['111', '22', ''], '(a) Some text')):
+                            (['111', '22', ''], '(a) Some text'),
+                            (['111', '22', 'a'], '  ')):
             node = {'label': label, 'text': text}
             self.assertFalse(HTMLBuilder.is_collapsed(node))


### PR DESCRIPTION
For #68, we set the position of li's to "relative", which produced some
unexpected results (e.g. horizontal scroll bars were not longer selectable).
Rather than use a relative+absolute approach for collapsed paragraphs, this
patch uses float. You will recall that "collapsed" paragraphs are those
paragraphs which consist of only a paragraph marker.

Also adds a test and fixes a problem where an empty paragraph (with _no_
marker) was considered collapsed.