### PR TITLE
Update "project repository" link from CFPB-specific site to eRegs site

### DIFF
--- a/regulations/templates/regulations/about.html
+++ b/regulations/templates/regulations/about.html
@@ -35,7 +35,7 @@
         <div class="content-secondary column-r well dev-well">
             <span class="cf-icon cf-icon-github"></span><span class="icon-text">Github</span>
             <h4>Developers</h4>
-            <p>eRegulations is an open source project. Visit <a href="http://cfpb.github.io/eRegulations/" class="external" aria-label="Link opens in a new window" target="_blank">the project repository</a> to learn more and contribute.</p>
+            <p>eRegulations is an open source project. Visit <a href="http://eregs.github.io/eRegulations/" class="external" aria-label="Link opens in a new window" target="_blank">the project repository</a> to learn more and contribute.</p>
         </div>
     </div>
     <div id="read" class="inner-wrap easy-read group">


### PR DESCRIPTION
Simple update (changing http://cfpb.github.io/eRegulations/ to http://eregs.github.io/eRegulations/) to help people find all the various eRegulations repositories (fixing https://github.com/18F/atf-eregs/issues/238).