### PR TITLE
Style Refactoring - remove .avenir naming convention

### DIFF
--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -10,6 +10,7 @@ Type & Layout
 ------------- */
 @import "normalize.less";
 @import "cf-icons.less";
+@import "variables.less";
 @import "mixins.less";
 @import "fonts.less";
 @import "typography.less";
@@ -117,7 +118,7 @@ Modules
 .alert {
     background-color: #F6D9D3;
     border: 1px solid #E8A091;
-    .avenir-next;
+    .font-regular;
 
     ul {
         .reset;
@@ -165,7 +166,7 @@ Modules
 }
 
 .error {
-    .avenir-next;
+    .font-regular;
     color: @red_orange;
     border-bottom: 1px solid @light_field;
     font-size: .9em;
@@ -181,7 +182,7 @@ Modules
 
 /* credit */
 #modal {
-    .avenir-next-demi;
+    .font-bold;
     color: @dark_gray;
     width: 400px;
     height: 400px;
@@ -196,7 +197,7 @@ Modules
         margin-top: 0;
 
         li {
-            .avenir-next;
+            .font-regular;
             margin-top: .75em;
         }
     }
@@ -228,7 +229,7 @@ Modules
 }
 
 #sig {
-    .avenir-next;
+    .font-regular;
 }
 
 .love {

--- a/regulations/static/regulations/css/less/mixins.less
+++ b/regulations/static/regulations/css/less/mixins.less
@@ -1,59 +1,23 @@
 /*
-LESS Mixins & Variables
+LESS Mixins 
  ==========================================================================
-mixins.less contains any mixins or variables to be used throughout the LESS files
+mixins.less contains any mixins to be used throughout the LESS files
 */
 
-/*
- Color Variables
- ----------------
- */
 
-@green: #2CB34A;
-@green_midtone: #ADDC91;
-@green_light: #DBEDD4;
-@black: #101820;
-@dark_field: #5C6065;
-@light_field: #D1D3D5;
-@grey: #E6E7E9;
-@red_orange: #D12124;
-@pacific: #0072CE;
-@link_blue: #348dc9; /* blue used for link borders and search results */
-@light_neutral: #D7D2CB;
-@dark_gray: #797D81
-; /* dark border */
-@bg_gray: #F7F8F9; /* background header */
-@medium_gray: #B8BABD; /* light border */
-@80_gray: #9A9DA1;
-@dark_text: #797D81;
-@mid_text: #43484E;
-@orange: #FBCD92;
-@light_orange: #FFECD1;
-@pacific_hover: #328ED8;
-@pacific_light: #CCE3F5;
-@red_orange_80: #D96A4F;
-@red_orange_50: #E9A193;
-
-/*
- Type Variables/Mixins
- ----------------------
-*/
-
-@body-font: Georgia, serif;
-
-.avenir-next {
+.font-regular {
     font-family: "Avenir Next", Arial, sans-serif;
     font-weight: normal;
     font-style: normal;
 }
 
-.avenir-next-demi {
+.font-bold {
     font-family: "Avenir Next Demi", Arial, sans-serif;
     font-weight: 600;
     font-style: normal;
 }
 
-.avenir-next-demi-italic {
+.font-italic {
     font-family: "Avenir Next Demi Italic", Arial, sans-serif;
     font-weight: 600;
     font-style: italic;

--- a/regulations/static/regulations/css/less/module/about.less
+++ b/regulations/static/regulations/css/less/module/about.less
@@ -7,7 +7,7 @@
 /* about-content is the same as landing-content, these should be unified into one class */
 .about-content {
     margin-top: 60px;
-    .avenir-next;
+    .font-regular;
 
     img {
         max-width: 100%;
@@ -40,7 +40,7 @@ hero
         font-size: 34px;
         padding: 24px 0;
         margin: 0;
-        .avenir-next;
+        .font-regular;
     }
 }
 

--- a/regulations/static/regulations/css/less/module/diffs.less
+++ b/regulations/static/regulations/css/less/module/diffs.less
@@ -23,11 +23,11 @@ ins {
     .key-term {
         background-color: @green_light;
         text-decoration: none;
-        .avenir-next-demi-italic;
-
+        .font-italic;
+        
         .level-2 &,
         .supplement-section .level-1 & {
-          .avenir-next-demi-italic; 
+          .font-italic; 
         }
     }
 
@@ -40,6 +40,6 @@ h2,
 h3,
 h4 {
     ins {
-        .avenir-next-demi-italic
+        .font-italic;
     }
 }

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -16,20 +16,20 @@ This contains all of the styles specific to the TOC
     }
 
     .toc-section-marker {
-      .avenir-next-demi;
+      .font-bold;
       display: block;
       font-size: 18px;
     }
 
     /* Interpretation Subparts in the TOC are styled differently */
     .toc-interp-heading {
-        .avenir-next;
+        .font-regular;
         text-transform: uppercase;
         font-size: 12px;
     }
 
     .toc-interp-title {
-        .avenir-next-demi;
+        .font-bold;
         font-size: 14px;
     }
 
@@ -97,7 +97,7 @@ This contains all of the styles specific to the TOC
 }
 
 .subpart-subhead {
-    .avenir-next-demi;
+    .font-bold;
     text-transform: none;
 }
 
@@ -109,7 +109,7 @@ This contains all of the styles specific to the history
 
 .history-drawer {
 
-    .avenir-next-demi;
+    .font-bold;
 
     ul,
     li {
@@ -122,7 +122,7 @@ This contains all of the styles specific to the history
 
     .effective-label {
         padding: 0 15px;
-        .avenir-next;
+        .font-regular;
         color: @dark_gray;
     }
 
@@ -182,7 +182,7 @@ This contains all of the styles specific to the history
     h3 {
         margin: 0;
         font-size: 1em;
-        .avenir-next-demi;
+        .font-bold;
     }
 
     h4 {
@@ -212,14 +212,14 @@ This contains all of the styles specific to the history
     .rule-status {
         color: @dark_text;
         text-transform: lowercase;
-        .avenir-next;
+        .font-regular;
         display: block;
         float: right;
     }
 
     .rule-list {
         margin: 0 15px;
-        .avenir-next;
+        .font-regular;
     }
 
     .rule-list li {
@@ -231,7 +231,7 @@ This contains all of the styles specific to the history
     }
 
     .version-date {
-        .avenir-next-demi;
+        .font-bold;
         font-size: 1.285714286em;
     }
 
@@ -352,7 +352,7 @@ This contains all of the styles specific to the search
 
     h4 {
         color: @dark_text;
-        .avenir-next;
+        .font-regular;
         text-transform: none;
         margin-bottom: 0.5em;
     }

--- a/regulations/static/regulations/css/less/module/drawer.less
+++ b/regulations/static/regulations/css/less/module/drawer.less
@@ -13,7 +13,7 @@ Universal drawer styles
 .panel {
     background-color: @bg_gray;
     border-right: 2px solid @medium_gray;
-    .avenir-next-demi;
+    .font-bold;
     font-size: .875em;
     overflow-y: scroll; /* allow content to be scrollable */
 }
@@ -58,7 +58,7 @@ Panel Header
     h2 {
         color: @mid_text;
         font-size: .875em; /* 12px / (26px * .875em) */
-        .avenir-next-demi;
+        .font-bold;
         text-transform: uppercase;
     }
 }

--- a/regulations/static/regulations/css/less/module/error.less
+++ b/regulations/static/regulations/css/less/module/error.less
@@ -12,7 +12,7 @@ error.less contains styles for the generic 404, history 404, and 500 pages
 
     p,
     li {
-        .avenir-next;
+        .font-regular;
     }
 
     h3 {

--- a/regulations/static/regulations/css/less/module/expandables.less
+++ b/regulations/static/regulations/css/less/module/expandables.less
@@ -1,6 +1,6 @@
 .expand-button {
     color: @pacific;
-    .avenir-next-demi;
+    .font-bold;
     display: inline-block;
     text-transform: uppercase;
     font-size: .8em;

--- a/regulations/static/regulations/css/less/module/footer.less
+++ b/regulations/static/regulations/css/less/module/footer.less
@@ -6,7 +6,7 @@ Global Footer
 .application-footer {
     padding: 15px;
     margin-left: 285px;
-    .avenir-next;
+    .font-regular;
     color: @dark_gray;
 
     abbr[title] {
@@ -32,7 +32,7 @@ Landing Page Footer
     margin: 3em 0;
     padding-top: 2em;
     .border-top-medium (@width: 2px);
-    .avenir-next;
+    .font-regular;
     font-size: 0.875em;
 
     .logo-wrap {
@@ -86,11 +86,11 @@ Next/Previous Links
 .next-prev {
     border-top: 2px solid @medium_gray;
     width: 45%;
-    .avenir-next-demi;
+    .font-bold;
 }
 
 .pager {
-    .avenir-next;
+    .font-regular;
     color: @dark_text;
     text-align: center;
 }

--- a/regulations/static/regulations/css/less/module/forms.less
+++ b/regulations/static/regulations/css/less/module/forms.less
@@ -11,7 +11,7 @@ input {
 
 input[type=text]{
     vertical-align: bottom;
-    .avenir-next;
+    .font-regular;
     color: @black;
 }
 

--- a/regulations/static/regulations/css/less/module/header.less
+++ b/regulations/static/regulations/css/less/module/header.less
@@ -5,7 +5,7 @@
 .reg-header {
     width: 100%;
     color: @dark_field;
-    .avenir-next;
+    .font-regular;
     position: absolute;
     height: 94px;
 
@@ -45,19 +45,19 @@
     }
 
     .reg-title {
-        .avenir-next;
+        .font-regular;
         font-size: 1.125em;
         max-height: 20px;
     }
 
     .site-title {
-        .avenir-next-demi;
+        .font-bold;
         font-size: 1.375em;
         padding-left: 15px;
     }
 
     .e {
-        .avenir-next;
+        .font-regular;
     }
 }
 
@@ -72,7 +72,7 @@
     .main-head {
         .reg-title:before {
             content: "|";
-            .avenir-next;
+            .font-regular;
             padding: 0 12px;
             color: @medium_gray;
         }
@@ -115,12 +115,12 @@
     }
 
     .subpart {
-        .avenir-next-demi;
+        .font-bold;
         display: inline;
     }
     .with-subpart:before {
         content: "|";
-        .avenir-next;
+        .font-regular;
         color: @dark_gray;
         display: inline-block;
         margin: 0 10px;
@@ -130,7 +130,7 @@
 .header-label {
     .reset;
     display: inline-block;
-    .avenir-next-demi;
+    .font-bold;
     font-size: 1em;
     letter-spacing: 1px;
     display: inline;
@@ -172,7 +172,7 @@ Application Nav
 .app-nav {
 
     a {
-        .avenir-next-demi;
+        .font-bold;
     }
 
     a:link,
@@ -377,7 +377,7 @@ Small Screens
         display: block;
 
         strong {
-            .avenir-next;
+            .font-regular;
         }
     }
 

--- a/regulations/static/regulations/css/less/module/interpretations.less
+++ b/regulations/static/regulations/css/less/module/interpretations.less
@@ -19,7 +19,7 @@
     h4 {
         color: @black;
         text-transform: uppercase;
-        .avenir-next;
+        .font-regular;
         display: inline-block;
         font-size: .8em;
         margin: 0;
@@ -29,7 +29,7 @@
 
     .expand-button {
         color: @pacific;
-        .avenir-next-demi;
+        .font-bold;
         position: absolute;
         display: inline-block;
         right: 0;
@@ -75,7 +75,7 @@
 
     .ref-num {
         text-transform: none;
-        .avenir-next-demi;
+        .font-bold;
     }
 
      p {
@@ -120,7 +120,7 @@
     }
 
     .section-link {
-        .avenir-next-demi;
+        .font-bold
     }
 
 }
@@ -135,7 +135,7 @@
 
 .appendix-note {
     ol {
-        .avenir-next;
+        .font-regular;
         color: @black;
         font-size: 0.875em;
         padding: 0;
@@ -149,7 +149,7 @@
     }
 
     h4 {
-        .avenir-next-demi;
+        .font-bold;
         background: none;
         padding: 0;
     }

--- a/regulations/static/regulations/css/less/module/navigation.less
+++ b/regulations/static/regulations/css/less/module/navigation.less
@@ -29,7 +29,7 @@ Appendix Navigation
 }
 
 .appendix-nav li {
-    .avenir-next-demi;
+    .font-bold;
     margin: 0;
     font-size: 0.875em; /*14px*/
     line-height: 1.85714; /*26px*/

--- a/regulations/static/regulations/css/less/module/reg-landing.less
+++ b/regulations/static/regulations/css/less/module/reg-landing.less
@@ -5,7 +5,7 @@ reg-landing.less contains styles specific to the regulation landing page
 */
 
 .banner-text {
-    .avenir-next;
+    .font-regular;
     font-size: 2em;
     line-height: 1.3;
     padding: 0 0 .5em 0;
@@ -14,7 +14,7 @@ reg-landing.less contains styles specific to the regulation landing page
 
 .landing {
     h4 {
-        .avenir-next;
+        .font-regular;
         display: inline;
         font-size: 1.125em;
         text-transform: none;
@@ -30,7 +30,7 @@ reg-landing.less contains styles specific to the regulation landing page
     }
 
     p, li {
-        .avenir-next;
+        .font-regular;
     }
 
     .effective-date {
@@ -42,7 +42,7 @@ reg-landing.less contains styles specific to the regulation landing page
 .landing-curent-link {
 
     a {
-        .avenir-next-demi;
+        .font-bold;
         display: inline-block;
         line-height: 20px;
     }
@@ -65,7 +65,7 @@ reg-landing.less contains styles specific to the regulation landing page
     }
 
     h4 {
-        .avenir-next-demi;
+        .font-bold;
     }
 }
 
@@ -110,7 +110,7 @@ Sidebar
         }
 
         h3 {
-            .avenir-next;
+            .font-regular;
             font-size: 1.285714286em;
             margin: 1.6em 0 1em 0;
         }
@@ -119,7 +119,7 @@ Sidebar
             color: @black;
             text-transform: none;
             margin-bottom: 0.5em;
-            .avenir-next-demi;
+            .font-bold;
             letter-spacing: normal;
         }
 

--- a/regulations/static/regulations/css/less/module/search-results.less
+++ b/regulations/static/regulations/css/less/module/search-results.less
@@ -9,14 +9,14 @@ search-results.less contains styles for search results
 }
 
 h2.search-term {
-    .avenir-next;
+    .font-regular;
     margin-bottom: 0;
 }
 
 p.search-version {
     color: @dark_gray;
     text-transform: uppercase;
-    .avenir-next-demi;
+    .font-bold;
     font-size: 0.875em;
     margin-top: 0;
 }
@@ -30,7 +30,7 @@ p.search-version {
     }
 
     h3 {
-        .avenir-next-demi;
+        .font-bold;
         margin-bottom: 0;
     }
 
@@ -57,7 +57,7 @@ p.search-version {
 
     a:link,
     a:visited {
-        .avenir-next-demi;
+        .font-bold;
         color: @pacific;
         text-decoration: none;
     }

--- a/regulations/static/regulations/css/less/module/sidebar.less
+++ b/regulations/static/regulations/css/less/module/sidebar.less
@@ -25,7 +25,7 @@ Sidebar
 */
 .secondary-content {
     font-size: .875em;
-    .avenir-next;
+    .font-regular;
 
     /* reset the margin and padding of all sidebar lists*/
     ul,
@@ -42,7 +42,7 @@ Headers within the sidebar should be <h4>
         text-transform: uppercase;
         letter-spacing: 1px;
         color: @mid_text;
-        .avenir-next-demi;
+        .font-bold;
 
         &.important {
             color: @red_orange;
@@ -127,7 +127,7 @@ Sidebar Headers
     h4 {
         color: @dark_gray;
         padding: .5em 0 .5em .9375em;
-        .avenir-next-demi;
+        .font-bold;
         text-transform: uppercase;
         padding-right: 25px;
     }
@@ -178,13 +178,13 @@ Regs Meta contains the sub-content meta data found in the sidebar
 
     h4 {
         padding: .5em 1em;
-        .avenir-next-demi;
+        .font-bold;
     }
 
     .subtitle {
         display: inline-block;
         margin: 0;
-        .avenir-next;
+        .font-regular;
         font-size: 1em;
         text-transform: none;
         padding-right: 10px;
@@ -201,7 +201,7 @@ Regs Meta contains the sub-content meta data found in the sidebar
         .sidebar-full:link,
         .sidebar-full:visited {
             display: block;
-            .avenir-next-demi;
+            .font-bold;
             color: @black;
             .border-bottom-light;
             padding: .5em;
@@ -250,7 +250,7 @@ When open definitions appear in the right sidebar
 
 .open-definition ol,
 .active-term {
-    .avenir-next-demi;
+    .font-bold;
 }
 
 .open-definition {
@@ -275,7 +275,7 @@ When open definitions appear in the right sidebar
     }
 
     p {
-        font-family: @body-font;
+        font-family: @body_font;
         font-weight: normal;
     }
 
@@ -309,7 +309,7 @@ When open definitions appear in the right sidebar
         padding: 1em 0 0 0;
 
         p {
-            .avenir-next;
+            .font-regular;
             font-size: .9em;
         }
 
@@ -343,7 +343,7 @@ When open definitions appear in the right sidebar
 continue links */
 .continue-link,
 .update-definition {
-    .avenir-next-demi;
+    .font-bold;
     display: inline-block;
     margin: 0 15px 0 0;
 }
@@ -412,7 +412,7 @@ Styles for the UI help slide down
     width: 60px;
     display: block;
     float: left;
-	font-family: @body-font;
+	font-family: @body_font;
 }
 
 .help-text {

--- a/regulations/static/regulations/css/less/module/sxs.less
+++ b/regulations/static/regulations/css/less/module/sxs.less
@@ -51,7 +51,7 @@ SxS header
     z-index: 100;
 
     h2 {
-        .avenir-next-demi;
+        .font-bold;
         font-size: 1em;
         margin: 0;
         padding-left: 15px;
@@ -73,7 +73,7 @@ Back link
 .sxs-back-button,
 .sxs-back-button:link,
 .sxs-back-button:visited {
-    .avenir-next-demi;
+    .font-bold;
     display: inline-block;
     padding: 0 15px;
     min-width: 5em;
@@ -137,7 +137,7 @@ Metadata info for the SxS Analysis
     margin-top: 84px;
     padding-bottom: 50px; /* prevent IE from cutting off the sidebar when it exceeds the window height */
     font-size: 0.875em;
-    .avenir-next;
+    .font-regular;
 
     ul,
     li {
@@ -152,7 +152,7 @@ Metadata info for the SxS Analysis
     h4 {
         margin-bottom: 0;
         color: @dark_gray;
-        .avenir-next-demi;
+        .font-bold;
     }
 
     h3 {
@@ -174,7 +174,7 @@ Metadata info for the SxS Analysis
 .analysis-list {
 
     a {
-        .avenir-next-demi;
+        .font-bold;
         font-size: 1.142857143em;
     }
 
@@ -215,7 +215,7 @@ Footnotes
 
     .reference-num {
         float: left;
-        .avenir-next-demi;
+        .font-bold;
     }
 
     .return-link {

--- a/regulations/static/regulations/css/less/module/universal-landing.less
+++ b/regulations/static/regulations/css/less/module/universal-landing.less
@@ -7,7 +7,7 @@
 /* offset the persistent header */
 .landing-content {
     margin-top: 60px;
-    .avenir-next;
+    .font-regular;
 
     .disclaimer {
         margin-top: 1em;
@@ -23,7 +23,7 @@
 .hero {
     background-color: @green_midtone;
     overflow: hidden;
-    .avenir-next;
+    .font-regular;
     .border-bottom-light;
 
     .inner-wrap {
@@ -56,7 +56,7 @@
 
 .hero-header {
     font-size: 2.125em;
-    .avenir-next;
+    .font-regular;
 }
 
 .hero-text {
@@ -107,7 +107,7 @@
         display: block;
         height: 100%;
         float: left;
-        .avenir-next-demi;
+        .font-bold;
         font-size: 1.375em;
         margin-right: 36px;
     }
@@ -164,7 +164,7 @@
 
 .notices {
     .reset;
-    .avenir-next;
+    .font-regular;
     font-size: 0.875em;
     min-height: 250px;
 }

--- a/regulations/static/regulations/css/less/print.less
+++ b/regulations/static/regulations/css/less/print.less
@@ -49,7 +49,7 @@ strong,
 
 /* ensure that styling the list markers doesn't override the body font style */
 .main-content p {
-  font-family: @body-font !important;
+  font-family: @body_font !important;
 }
 /*
  Page Breaks & Orphans

--- a/regulations/static/regulations/css/less/typography.less
+++ b/regulations/static/regulations/css/less/typography.less
@@ -15,7 +15,7 @@ typography.less contains both global and application specific typography */
 
 body {
     color: @black;
-    font-family: @body-font;
+    font-family: @body_font;
     font-size: 1em;
     /*line-height: 1.625;*/ /* 26px */
     /*line-height: 1.375;*/ /*22px*/
@@ -23,7 +23,7 @@ body {
 }
 
 strong {
-    .avenir-next-demi;
+    .font-bold;
 }
 
 /*  Default Headings
@@ -38,15 +38,11 @@ strong {
 
 h1,
 h2,
-h3{
-    .avenir-next-demi;
-    margin-bottom: 0;
-}
-
+h3,
 h4,
 h5,
 h6 {
-    .avenir-next-demi;
+    .font-bold;
     margin-bottom: 0;
 }
 
@@ -83,7 +79,7 @@ h6 {
 */
 
 .sub-text {
-    .avenir-next;
+    .font-regular;
 }
 
 .small-header {
@@ -95,7 +91,7 @@ h6 {
 }
 
 .light-header {
-    .avenir-next;
+    .font-regular;
 }
 
 .upper-header {
@@ -271,7 +267,7 @@ a:visited {
 /* button styles */
 
 .btn {
-    .avenir-next;
+    .font-regular;
     display: inline-block;
     box-sizing: border-box;
     padding: .57142857em 1em;
@@ -315,7 +311,7 @@ a:visited {
 .appendix-heading,
 .supplement-section h3 {
     font-size: 1.8125em; /* 29px / 16 */
-    .avenir-next-demi;
+    .font-bold;
     line-height: 1.25;
     letter-spacing: 1px;
 }
@@ -377,7 +373,7 @@ This attempts to define global rules for a clear hierarchical structure.
 }
 
 /*
-The list & key-terms are set to Avenir Next Demi
+The list & key-terms are set to the theme bold font
 Paragraphs within the list items are set in the body font
 The `<ol>` tag needs to have the appropriate list type applied
 ```
@@ -393,7 +389,7 @@ The `<ol>` tag needs to have the appropriate list type applied
 */
 
 .main-content ol, dfn, .stripped-marker {
-  .avenir-next-demi;
+  .font-bold;
 }
 
 .appendix-section ol {
@@ -401,7 +397,7 @@ The `<ol>` tag needs to have the appropriate list type applied
 }
 
 .main-content p {
-  font-family: @body-font;
+  font-family: @body_font;
   font-weight: 400;
 }
 
@@ -473,7 +469,7 @@ All key-terms are displayed as block elements to force a line-break.
 .supplement-section .level-1 .key-term {
     text-transform: uppercase;
     font-size: 1em;
-    .avenir-next-demi;
+    .font-bold;
 }
 
 /*  Level-3 key-terms
@@ -491,7 +487,7 @@ All key-terms are displayed as block elements to force a line-break.
 */
 
 .level-3 .key-term {
-    .avenir-next-demi;
+    .font-bold;
     text-transform: none;
 }
 
@@ -516,7 +512,6 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
     font-size: 0.875em; /* 14/16 = .875 */
     line-height: 1.4;
 }
-
 
 /* some model forms have dashes in the regulation, such as
 * Location ________
@@ -554,8 +549,6 @@ Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliqu
     }
 }
 
-
-
 /*
   Table Styles
  ========================================================================== */
@@ -563,7 +556,7 @@ table {
     margin: 1em 0;
     padding: 0;
     font-size: .75em;
-    .avenir-next;
+    font-family: Helvetica Neue,Helvetica,Arial,sans-serif;
     table-layout: auto;
     width: 100%;
 }
@@ -576,19 +569,50 @@ td {
 }
 
 th {
-    font-family: "Avenir Next Demi", Arial, sans-serif;
-    font-weight: 600;
+    font-weight: bold;
     font-style: normal;
     text-align: left;
+}
+
+td {
+    font-weight: normal;
 }
 
 thead {
     background-color: #fff;
 }
-
+    
 .table-wrap {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch; // smoother scrolling        
+    -webkit-overflow-scrolling: touch; // smoother scrolling
+}
+
+/*
+    Datatables-specific css
+*/
+
+.dataTable {
+    table& {
+        margin-top:0;
+        thead {
+            height:0;
+        }
+        tr:first-child td {
+            border-top: none;
+        }
+    }
+}
+
+.dataTables_scrollHeadInner {
+    div& {
+        table {
+            margin-bottom: 0px; 
+        }
+    }
+}
+table.dataTable, table.dataTable th, table.dataTable td {
+    -webkit-box-sizing: content-box;
+    -moz-box-sizing: content-box;
+    box-sizing: content-box;
 }
 
 /*

--- a/regulations/static/regulations/css/less/variables.less
+++ b/regulations/static/regulations/css/less/variables.less
@@ -1,0 +1,41 @@
+/*
+==========================================================================
+variables.less contains all theme variable / variable overrides
+*/
+
+/*
+ Color Variables
+ ----------------
+ */
+
+@green: #2CB34A;
+@green_midtone: #ADDC91;
+@green_light: #DBEDD4;
+@black: #101820;
+@dark_field: #5C6065;
+@light_field: #D1D3D5;
+@grey: #E6E7E9;
+@red_orange: #D12124;
+@pacific: #0072CE;
+@link_blue: #348dc9; /* blue used for link borders and search results */
+@light_neutral: #D7D2CB;
+@dark_gray: #797D81
+; /* dark border */
+@bg_gray: #F7F8F9; /* background header */
+@medium_gray: #B8BABD; /* light border */
+@80_gray: #9A9DA1;
+@dark_text: #797D81;
+@mid_text: #43484E;
+@orange: #FBCD92;
+@light_orange: #FFECD1;
+@pacific_hover: #328ED8;
+@pacific_light: #CCE3F5;
+@red_orange_80: #D96A4F;
+@red_orange_50: #E9A193;
+
+/*
+ Type Variables
+ ----------------------
+*/
+
+@body_font: Georgia, serif;


### PR DESCRIPTION
Breaking the style code refactoring into more palatable chunks.  

- Refactored .avenir* mixins to a more generic naming convention.  
- Created a separate .less file for variables.
- Changed body-font variable to match underscore-based naming convention for variables.  
- Ported table css styling implemented in atf-eregs to support scrolling tables (datatables js plugin).

The main goal of this PR is to change the literal naming convention of the .avenir* mixins to a more generic, portable naming convention.  The generic naming convention falls across a general usage pattern of regular / bold / italic.

Jen's theme will require further refining of font mixins - I will break those out in future PRs. 