### PR TITLE
turn off caching during dev

### DIFF
--- a/regulations/settings/dev.py
+++ b/regulations/settings/dev.py
@@ -3,6 +3,10 @@ from .base import *
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
 
+CACHES['default']['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
+CACHES['eregs_longterm_cache']['BACKEND'] = 'django.core.cache.backends.dummy.DummyCache'
+CACHES['api_cache']['TIMEOUT'] = 5  # roughly per request
+
 OFFLINE_OUTPUT_DIR = '/tmp/'
 
 INSTALLED_APPS += (


### PR DESCRIPTION
settings to turn off caching during development pulled from atf-eregs