### PR TITLE
bugfix: centering key terms on paragraph markers

### DIFF
--- a/regulations/static/regulations/css/less/module/paragraph-markers.less
+++ b/regulations/static/regulations/css/less/module/paragraph-markers.less
@@ -50,6 +50,7 @@ ol, li {
   }
 }
 
+// reset margins for ordered lists
 ol {
   margin-top: 0;
 
@@ -59,5 +60,16 @@ ol {
 }
 
 .level-2 > li > p {
-    margin-top: 0;
+    margin-top: 1em;
+}
+
+// move key term headings up to center with paragraph markers
+.paragraph-marker + .key-term {
+  float: left;
+  margin-top: -5px;
+  width: 100%;
+}
+
+.level-2 .paragraph-marker + .key-term {
+  margin: 0;
 }

--- a/regulations/static/regulations/css/less/module/paragraph-markers.less
+++ b/regulations/static/regulations/css/less/module/paragraph-markers.less
@@ -63,7 +63,15 @@ ol {
     margin-top: 1em;
 }
 
-// move key term headings up to center with paragraph markers
+/*
+   Move key term headings up to center with paragraph markers
+-- note: we generically set properties for all the key terms
+   despite wanting to target only level-1 key terms because of
+   the way the ordered list classes are set. setting level-2
+   properties then "unsets" the properties originally intended
+   for level-1 because of the way the properties cascade down
+   (setting for level-2 actually sets for level-2 and all levels below)
+*/
 .paragraph-marker + .key-term {
   float: left;
   margin-top: -5px;


### PR DESCRIPTION
Assigning a negative top margin on key terms when on paragraph markers to make them appear visually center. Level 2 paragraphs have a top margin to account for key terms not being off as well.