### PR TITLE
Add template tag for creating a list

### DIFF
--- a/regulations/templatetags/to_list.py
+++ b/regulations/templatetags/to_list.py
@@ -1,0 +1,12 @@
+"""Particularly when displaying bullets, it can be immensely helpful to
+construct a list _within_ the template. Django's templates don't provide this
+out of the box, so we need a new template tag. Suggestion from:
+    http://stackoverflow.com/a/34407158"""
+from django import template
+
+register = template.Library()
+
+
+@register.assignment_tag
+def to_list(*args):
+    return args

--- a/regulations/templatetags/to_list.py
+++ b/regulations/templatetags/to_list.py
@@ -1,7 +1,14 @@
 """Particularly when displaying bullets, it can be immensely helpful to
 construct a list _within_ the template. Django's templates don't provide this
 out of the box, so we need a new template tag. Suggestion from:
-    http://stackoverflow.com/a/34407158"""
+    http://stackoverflow.com/a/34407158
+
+Usage:
+    {% to_list "a" "b" "c" as my_list %}
+    {% for el in my_list %}
+        {{ el }}
+    {% endfor %}
+"""
 from django import template
 
 register = template.Library()


### PR DESCRIPTION
This also allows us to pass a list in as a variable to a template, which, in
turn, allows us to make things like a re-usable landing page search template
for ATF

In service of 18f/atf-eregs#385