### PR TITLE
Updates for accessibility

### DIFF
--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -131,7 +131,7 @@ Modules
 
 .well {
     padding: 1em 1.25em;
-    background: @grey;
+    background: @bg_grey;
 }
 
 .bump {

--- a/regulations/static/regulations/css/less/main.less
+++ b/regulations/static/regulations/css/less/main.less
@@ -131,7 +131,7 @@ Modules
 
 .well {
     padding: 1em 1.25em;
-    background: @bg_grey;
+    background: @bg_gray;
 }
 
 .bump {

--- a/regulations/static/regulations/css/less/module/drawer-content.less
+++ b/regulations/static/regulations/css/less/module/drawer-content.less
@@ -226,19 +226,12 @@ This contains all of the styles specific to the history
 
     .select-content {
         margin: 6px 15px 15px 15px;
-        background: white url('../img/select-blue.png') no-repeat bottom right;
     }
 
-
-    @media
-    (-webkit-min-device-pixel-ratio: 2),
-    (min-resolution: 192dpi) {
-        .select-content {
-            background: white url('../img/select-blue@2x.png') no-repeat bottom right;
-            background-size: 32px 32px;
-        }
+    .diff-button-wrapper {
+        text-align: center;
+        margin-bottom: 1em;
     }
-
 }
 
 .js {

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -94,6 +94,7 @@
                   <button type="submit" class="find-button">Find</button>
                 </form>
                 </div><!--./date-form-->
+                {% comment %}TODO: Indentation here is all kinds of funky {% endcomment %}
                 <ul class="version-list" id="history-toc-list">
                 {% for version in history %}
                     <li class="{% if version.version == active_version %}current {% endif %}status-list" data-base-version="{{version.version}}">
@@ -115,23 +116,25 @@
                                 {% endif %}
                               {% endwith %}
                             {% endfor %}
-                                </ul>
-                                <div class="diff-selector group">
-                                <h4 class="compare-title">Compare this with</h4>
-                                <div class="select-content">
+                            </ul>
+                            <div class="diff-selector group">
+                                <h4 class="compare-title">Compare {{reg_part}} effective on {{version.by_date|date}} with</h4>
                                 <form action="{% url 'diff_redirect' diff_redirect_label active_version %}" method="GET">
-                                    <select name="new_version" onChange="this.form.submit();" title="Compare version">
-                                        <option value="default" disabled="disabled" selected="selected">regulation effective</option>
+                                  <div class="select-content">
+                                    <select name="new_version" title="Compare version">
                                         {% for version in history %}
                                             {% if active_version != version.version %}
                                                 <option value="{{version.version}}">{{version.by_date|date}}</option>
                                             {% endif %}
                                         {% endfor %}
                                     </select>
+                                  </div> <!--/.select-content-->
+                                  <div class="diff-button-wrapper">
+                                      <button>Show Differences</button>
+                                  </div>
                                 </form>
-                            </div> <!--/.select-content-->
-                        </div><!--/.diff-selector-->
-                    </div><!--/.timeline-content-wrap-->
+                            </div><!--/.diff-selector-->
+                        </div><!--/.timeline-content-wrap-->
                     </li>
                 {% endfor %}
                 </ul>

--- a/regulations/templates/regulations/diff-chrome.html
+++ b/regulations/templates/regulations/diff-chrome.html
@@ -89,7 +89,6 @@ Comparison of {{meta.cfr_title_number}} CFR {{formatted_id}} | eRegulations
                       {% endfor %}
                     </ul>
                         {% if version.version == left_version %}
-                        <h4 class="compare-title">Compare this with</h4>
                         <a data-first-subterp="{{first_subterp.section_id}}" class="stop-button" data-version="{{ from_version }}"
                             {% if "Interp" in label_id %}
                             href="{{first_subterp.url}}"


### PR DESCRIPTION
* Updates the grey box on the "about" page to have higher contrast
* Removes auto-submit on diff version selection
* Adds a submit button in its place

<img width="231" alt="screen shot 2016-02-24 at 6 48 34 pm" src="https://cloud.githubusercontent.com/assets/326918/13305210/b607c1aa-db27-11e5-94c0-359a9f5ee343.png">
<img width="231" alt="screen shot 2016-02-24 at 6 48 23 pm" src="https://cloud.githubusercontent.com/assets/326918/13305211/b60c26aa-db27-11e5-9aa9-4effc87f29c9.png">

Resolves 18f/atf-eregs#378
