### PR TITLE
Remove four chrome view classes

### DIFF
--- a/regulations/tests/views_chrome_tests.py
+++ b/regulations/tests/views_chrome_tests.py
@@ -72,10 +72,10 @@ class ViewsChromeTest(TestCase):
         response = Client().get('/regulation/111/222')
         self.assertEqual(404, response.status_code)
 
-
-class ViewsChromeRegulationTest(TestCase):
-    def test_diff_redirect_label(self):
-        view = chrome.ChromeRegulationView()
+    def test_diff_redirect_label_regulation(self):
+        """If viewing a full regulation, the redirect for diffs should point
+        to the first section"""
+        view = chrome.ChromeView()
         toc = [{'section_id': '199-Subpart-A',
                 'sub_toc': [{'section_id': '199-4'}, {'section_id': '199-6'}]},
                {'section_id': '199-Subpart-B',

--- a/regulations/tests/views_chrome_tests.py
+++ b/regulations/tests/views_chrome_tests.py
@@ -82,10 +82,11 @@ class ViewsChromeTest(TestCase):
                 'sub_toc': [{'section_id': '199-8'}, {'section_id': '199-9'}]}]
         self.assertEqual('199-4', view.diff_redirect_label('199', toc))
 
-
-class ViewsChromeParagraphView(TestCase):
-    def test_diff_redirect_label(self):
-        view = chrome.ChromeParagraphView()
+    def test_diff_redirect_label_paragraph(self):
+        """If viewing a single paragraph, the redirect for diffs should point
+        to that paragraph's section. Similarly, all diffs for interpretations
+        should point to the root interpretation"""
+        view = chrome.ChromeView()
         self.assertEqual('199-4', view.diff_redirect_label('199-4-b', []))
         self.assertEqual('199-4', view.diff_redirect_label('199-4-b-3', []))
         self.assertEqual('199-A', view.diff_redirect_label('199-A', []))

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -5,7 +5,7 @@ from django.views.decorators.cache import cache_page
 from regulations.views.about import about
 from regulations.views.chrome_breakaway import ChromeSXSView
 from regulations.views.chrome import (
-    ChromeView, ChromeLandingView, ChromeParagraphView,
+    ChromeView, ChromeLandingView,
     ChromeSearchView,
     ChromeSubterpView)
 from regulations.views.diff import ChromeSectionDiffView
@@ -98,7 +98,9 @@ urlpatterns = patterns(
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704
     url(r'^%s/%s$' % (paragraph_pattern, version_pattern),
-        lt_cache(ChromeParagraphView.as_view()),
+        lt_cache(ChromeView.as_view(
+            partial_class=PartialParagraphView,
+            version_switch_view='chrome_paragraph_view')),
         name='chrome_paragraph_view'),
     # A regulation landing page
     # Example: http://.../201

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -6,7 +6,7 @@ from regulations.views.about import about
 from regulations.views.chrome_breakaway import ChromeSXSView
 from regulations.views.chrome import (
     ChromeView, ChromeLandingView, ChromeParagraphView,
-    ChromeRegulationView, ChromeSearchView,
+    ChromeSearchView,
     ChromeSubterpView)
 from regulations.views.diff import ChromeSectionDiffView
 from regulations.views.diff import PartialSectionDiffView
@@ -91,7 +91,9 @@ urlpatterns = patterns(
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704
     url(r'^%s/%s$' % (reg_pattern, version_pattern),
-        lt_cache(ChromeRegulationView.as_view()),
+        lt_cache(ChromeView.as_view(
+            partial_class=PartialRegulationView,
+            version_switch_view='chrome_regulation_view')),
         name='chrome_regulation_view'),
     # A regulation paragraph with chrome
     # Example: http://.../201-2-g/2013-10704

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -5,8 +5,8 @@ from django.views.decorators.cache import cache_page
 from regulations.views.about import about
 from regulations.views.chrome_breakaway import ChromeSXSView
 from regulations.views.chrome import (
-    ChromeInterpView, ChromeLandingView, ChromeParagraphView,
-    ChromeRegulationView, ChromeSearchView, ChromeSectionView,
+    ChromeView, ChromeLandingView, ChromeParagraphView,
+    ChromeRegulationView, ChromeSearchView,
     ChromeSubterpView)
 from regulations.views.diff import ChromeSectionDiffView
 from regulations.views.diff import PartialSectionDiffView
@@ -73,7 +73,7 @@ urlpatterns = patterns(
     # A regulation section with chrome
     # Example: http://.../201-4/2013-10704
     url(r'^%s/%s$' % (section_pattern, version_pattern),
-        lt_cache(ChromeSectionView.as_view()),
+        lt_cache(ChromeView.as_view(partial_class=PartialSectionView)),
         name='chrome_section_view'),
     # Subterp, interpretations of a while subpart, emptypart or appendices
     # Example: http://.../201-Subpart-A-Interp/2013-10706
@@ -85,7 +85,8 @@ urlpatterns = patterns(
     # Interpretation of a section/paragraph or appendix
     # Example: http://.../201-4-Interp/2013-10704
     url(r'^%s/%s$' % (interp_pattern, version_pattern),
-        lt_cache(ChromeInterpView.as_view()),
+        lt_cache(ChromeView.as_view(
+            partial_class=partial_interp.PartialInterpView)),
         name='chrome_interp_view'),
     # The whole regulation with chrome
     # Example: http://.../201/2013-10704

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -8,8 +8,7 @@ from regulations.generator.subterp import filter_by_subterp
 from regulations.generator.toc import fetch_toc
 from regulations.generator.versions import fetch_grouped_history
 from regulations.views import utils
-from regulations.views.partial_interp import (
-    PartialInterpView, PartialSubterpView)
+from regulations.views.partial_interp import PartialSubterpView
 from regulations.views.reg_landing import regulation_exists, get_versions
 from regulations.views.reg_landing import regulation as landing_page
 from regulations.views.partial import PartialParagraphView
@@ -25,6 +24,7 @@ class ChromeView(TemplateView):
     #   Which view name to use when switching versions
     version_switch_view = 'chrome_section_view'
     sidebar_components = SideBarView.components
+    partial_class = None
 
     def check_tree(self, context):
         """Throw an exception if the requested section doesn't exist"""
@@ -116,16 +116,6 @@ class ChromeView(TemplateView):
         self._assert_good(response)
         response.render()
         return response.content
-
-
-class ChromeInterpView(ChromeView):
-    """Interpretation of regtext section/paragraph or appendix with chrome"""
-    partial_class = PartialInterpView
-
-
-class ChromeSectionView(ChromeView):
-    """Regtext section with chrome"""
-    partial_class = PartialSectionView
 
 
 class ChromeParagraphView(ChromeView):

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -12,7 +12,7 @@ from regulations.views.partial_interp import PartialSubterpView
 from regulations.views.reg_landing import regulation_exists, get_versions
 from regulations.views.reg_landing import regulation as landing_page
 from regulations.views.partial import PartialParagraphView
-from regulations.views.partial import PartialRegulationView, PartialSectionView
+from regulations.views.partial import PartialSectionView
 from regulations.views.partial_search import PartialSearch
 from regulations.views.sidebar import SideBarView
 from regulations.views import error_handling
@@ -59,9 +59,13 @@ class ChromeView(TemplateView):
         context['main_content_template'] = view.template_name
 
     def diff_redirect_label(self, label_id, toc):
-        """Most of the time, we want diff_redirect to link to *this*
-        section's label. This gives us an out for when we need to link
-        somewhere else."""
+        """We only display diffs for sections and appendices. All other types
+        of content must be converted to an appropriate diff label"""
+        label_parts = label_id.split('-')
+        if len(label_parts) == 1:   # whole CFR part. link to first section
+            while toc:
+                label_id = toc[0]['section_id']
+                toc = toc[0].get('sub_toc')
         return label_id
 
     def set_chrome_context(self, context, reg_part, version):
@@ -131,20 +135,6 @@ class ChromeParagraphView(ChromeView):
             return label[0] + '-Interp'
         else:
             return '-'.join(label[:2])
-
-
-class ChromeRegulationView(ChromeView):
-    """Entire regulation with chrome"""
-    partial_class = PartialRegulationView
-    version_switch_view = 'chrome_regulation_view'
-
-    def diff_redirect_label(self, label_id, toc):
-        """We don't do diffs of the whole reg; instead link to the first
-        section"""
-        while toc:
-            label_id = toc[0]['section_id']
-            toc = toc[0].get('sub_toc')
-        return label_id
 
 
 class ChromeSubterpView(ChromeView):


### PR DESCRIPTION
This takes a small step towards reducing the proliferation of "Chrome" classes by combining/replacing four of them. This is possible due to either combining logic or configuring the classes at instantiation time.

Work for 18f/atf-eregs#207