### PR TITLE
Don't add hash to URL on search results.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -158,7 +158,7 @@ var ChildView = Backbone.View.extend({
                 this.navigate(url);
                 $('html, body').scrollTop($('#' + options.scrollToId).offset().top);
             } else {
-                if (options.type !== 'diff') {
+                if (['diff', 'search-results'].indexOf(options.type) === -1) {
                     url += '#' + options.id;
                 }
                 this.navigate(url);


### PR DESCRIPTION
Rendering search results currently duplicates the path and query string
after the hash at the end of the URL. This makes URLs look strange
without any benefit, since the search results view doesn't have anchors
to scroll to. This patch adds `"search-results"` to the list of child
views on which we don't add the hash to the URL.

Before:
https://atf-eregs.apps.cloud.gov/search/447?q=smokes&version=2015-12992#447?q=smokes&version=2015-12992

After:
https://atf-eregs.apps.cloud.gov/search/447?q=smokes&version=2015-12992