### PR TITLE
Drop URL helper.

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "jquery-scrollstop": "1.2.0",
     "query-command-supported": "1.0.0",
     "respond.js": "1.4.2",
-    "underscore": "1.8.3"
+    "underscore": "1.8.3",
+    "urijs": "1.17.1"
   },
   "config": {
     "travis-cov": {

--- a/regulations/static/regulations/js/source/helpers.js
+++ b/regulations/static/regulations/js/source/helpers.js
@@ -287,32 +287,5 @@ module.exports = {
     toggleExpandable: function($expandable, dur) {
         $expandable.toggleClass('open')
           .next('.chunk').slideToggle(dur);
-    },
-
-    // thanks, James Padolsey http://james.padolsey.com/javascript/parsing-urls-with-the-dom/
-    parseURL: function(url) {
-        var a =  document.createElement('a');
-        a.href = url;
-        return {
-            source: url,
-            protocol: a.protocol.replace(':',''),
-            host: a.hostname,
-            port: a.port,
-            query: a.search,
-            params: (function(){
-                var ret = {},
-                    seg = a.search.replace(/^\?/,'').split('&'),
-                    len = seg.length, i = 0, s;
-                for (;i<len;i++) {
-                    if (!seg[i]) { continue; }
-                    s = seg[i].split('=');
-                    ret[s[0]] = s[1];
-                }
-                return ret;
-            })(),
-            hash: a.hash.replace('#',''),
-            path: a.pathname.replace(/^([^\/])/,'/$1'),
-            segments: a.pathname.replace(/^\//,'').split('/')
-        };
     }
 };

--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -149,8 +149,7 @@ var ChildView = Backbone.View.extend({
 
     route: function(options) {
         if (Router.hasPushState && typeof options.noRoute === 'undefined') {
-            var url = this.url,
-                hashPosition;
+            var url = this.url;
 
             // if a hash has been passed in
             if (options && typeof options.scrollToId !== 'undefined') {

--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -1,6 +1,7 @@
 'use strict';
 var $ = require('jquery');
 var _ = require('underscore');
+var URI = require('urijs');
 var DataTable = require('datatables.net')();
 var Clipboard = require('clipboard');
 var QueryCommand = require('query-command-supported');
@@ -75,9 +76,8 @@ var MainView = Backbone.View.extend({
 
         // find search query
         if (this.contentType === 'search-results') {
-            childViewOptions.id = Helpers.parseURL(window.location.href);
-            childViewOptions.params = childViewOptions.id.params;
-            childViewOptions.query = childViewOptions.id.params.q;
+            childViewOptions.params = URI.parseQuery(window.location.search);
+            childViewOptions.query = childViewOptions.params.q;
         }
 
         if (this.contentType === 'landing-page') {

--- a/regulations/static/regulations/js/unittests/specs/helpers-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/helpers-spec.js
@@ -223,14 +223,3 @@ describe('Version Finder Helper Functions:', function() {
     });
 
 });
-
-describe('Other Helper Functions:', function() {
-
-    'use strict';
-
-    xit('parseURL should parse correctly', function() {
-        // This method requires the DOM
-    });
-
-
-});


### PR DESCRIPTION
Drop a hack that uses the DOM to parse URLs for a cleaner,
fuller-featured URL library.

@cmc333333 @xtine: urijs is ~1.7kb minified, so I'm not worried about the asset bundle getting bigger, but we can also write a much simpler helper function to replace the DOM hack that I'm proposing we drop.