### PR TITLE
Prevent duplicate network error notifications

### DIFF
--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -194,9 +194,12 @@ var MainView = Backbone.View.extend({
     },
 
     displayError: function() {
+        // prevent error warning stacking
+        $('.error-network').remove();
+
         // get ID of still rendered last section
         var oldId = this.$el.find('section[data-page-type]').attr('id'),
-            $error = this.$el.prepend('<div class="error"><span class="cf-icon cf-icon-error icon-warning"></span>Due to a network error, we were unable to retrieve the requested information.</div>');
+            $error = this.$el.prepend('<div class="error error-network"><span class="cf-icon cf-icon-error icon-warning"></span>Due to a network error, we were unable to retrieve the requested information.</div>').hide().fadeIn('slow');
 
         DrawerEvents.trigger('section:open', oldId);
         HeaderEvents.trigger('section:open', oldId);
@@ -205,7 +208,6 @@ var MainView = Backbone.View.extend({
         SidebarEvents.trigger('section:error');
 
         window.scrollTo($error.offset().top, 0);
-
     },
 
     render: function(html, options) {


### PR DESCRIPTION
Currently, the only function to display an error to the user specifically just spits out a network error message. A quick fix to prevent stacking of network error notifications is to remove existing warnings before displaying another one. I also added a fade in effect to the content area so the user can visually know the error still persists if they query again.

Also a note that if we want to show different types of warnings other than "network error", we should probably rewrite the `displayError` function.