### PR TITLE
Identify label containment by common path prefixes

### DIFF
--- a/regulations/generator/layers/footnotes.py
+++ b/regulations/generator/layers/footnotes.py
@@ -1,4 +1,5 @@
 from regulations.generator.layers.base import LayerBase
+from regulations.generator.layers.utils import is_contained_in
 
 
 class FootnotesLayer(LayerBase):
@@ -15,15 +16,13 @@ class FootnotesLayer(LayerBase):
         """
         Return a tuple of 'footnotes' and collection of footnotes.
         Footnotes are "collected" from the node and its children.
-        In the layer data, child nodes have their label prefix equal
-        to that of their parent.
         .. note::
            This does not handle the case where the same note reference
            is used in multiple children.
         """
         footnotes = []
         for label in self.layer.keys():
-            if label.startswith(text_index):
+            if is_contained_in(label, text_index):
                 footnotes += [x['footnote_data']
                               for x in self.layer[label]
                               if 'footnote_data' in x]

--- a/regulations/generator/layers/utils.py
+++ b/regulations/generator/layers/utils.py
@@ -27,3 +27,15 @@ def convert_to_python(data):
 def render_template(template, context):
     c = Context(context)
     return template.render(c).strip('\n')
+
+
+def is_contained_in(child, parent):
+    '''
+        Return True if child is a child node of the parent.
+
+        Node labels are hierarchical paths, with segments separated
+        by '-'. As an edge case, a node label is also a child of itself.
+    '''
+    child_segments = child.split('-')
+    parent_segments = parent.split('-')
+    return child_segments[:len(parent_segments)] == parent_segments

--- a/regulations/tests/layers_utils_tests.py
+++ b/regulations/tests/layers_utils_tests.py
@@ -17,3 +17,9 @@ class LayerUtilsTest(TestCase):
         self.assertEqual({'some': 3, 'then': datetime(1999, 10, 21)},
                          utils.convert_to_python({'some': 3,
                                                   'then': '1999-10-21'}))
+
+    def test_is_contained_in(self):
+        self.assertTrue(utils.is_contained_in('22-51-12', '22-51'))
+        self.assertTrue(utils.is_contained_in('22-51-13', '22-51'))
+        self.assertTrue(utils.is_contained_in('22-51', '22-51'))
+        self.assertFalse(utils.is_contained_in('22-512', '22-51'))


### PR DESCRIPTION
Relying on string prefixes instead of checking '-' separated paths
resulted in identifying spurious parents.