### PR TITLE
Display Preambles

### DIFF
--- a/regulations/generator/api_reader.py
+++ b/regulations/generator/api_reader.py
@@ -114,3 +114,7 @@ class ApiReader(object):
         if regulation:
             params['regulation'] = regulation
         return self.client.get('search', params)
+
+    def preamble(self, doc_number):
+        return self._get(
+            ['preamble', doc_number], 'preamble/{}'.format(doc_number))

--- a/regulations/static/regulations/js/source/views/drawer/toc-view.js
+++ b/regulations/static/regulations/js/source/views/drawer/toc-view.js
@@ -14,8 +14,8 @@ var TOCView = Backbone.View.extend({
     el: '#table-of-contents',
 
     events: {
-        'click a.diff': 'sendDiffClickEvent',
-        'click a:not(.diff)': 'sendClickEvent'
+        'click a.diff[data-section-id]': 'sendDiffClickEvent',
+        'click a[data-section-id]:not(.diff)': 'sendClickEvent'
     },
 
     initialize: function() {

--- a/regulations/templates/regulations/chrome.html
+++ b/regulations/templates/regulations/chrome.html
@@ -39,6 +39,7 @@
        class="drawer-toggle-icon" alt="Open navigation drawer" /><img src="{%static "regulations/img/close-caret.svg" %}"
        class="drawer-toggle-icon" alt="Close navigation drawer"/></a>
         <ul class="drawer-toggles">
+          {% block sidebar-icons %}
             {% block sidebar-toc-link %}
             <li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents"><span class="icon-text">Table of Contents</span><img src="{%static "regulations/img/table-of-contents.svg" %}"
        class="drawer-toggle-icon" alt="Table of Contents toggle" /></a></li>
@@ -51,12 +52,15 @@
             <li><a href="#search" id="search-link" class="toc-nav-link" title="Search"><span class="icon-text">Search</span><img src="{%static "regulations/img/search.svg" %}"
        class="drawer-toggle-icon" alt="Search toggle"/></a></li>
             {% endblock %}
+          {% endblock %}
         </ul>
     </div> <!-- /toc-head-->
     <div id="content-header" class="header-main group">
         <div class="wayfinding">
+          {% block wayfinding %}
             <span class="subpart"></span>
             <span id="active-title">{% block active_title %}<em class="header-label"><span class="reg_part">§{{ reg_part }}</span></em>{% endblock %}</span>
+          {% endblock %}
         </div>
         {% block header-secondary %}
         <span class="effective-date"><strong>Effective Date:</strong> {{ meta.effective_date|date }}</span>
@@ -69,6 +73,7 @@
     We include the drawer in-line so that we can use blocks
     http://stackoverflow.com/questions/9633387/django-using-blocks-in-included-templates
 {% endcomment %}
+{% block whole-toc %}
 {% with active_version=version %}
 <div id="menu" class="panel" data-reg-id="{{ reg_part }}" data-cfr-title-number="{{meta.cfr_title_number}}">
     {% block drawer-toc %}
@@ -165,6 +170,7 @@
     </div> <!--/#search-->
 </div> <!-- /.panel -->
 {% endwith %}
+{% endblock %}
 
 <div class="wrap group">
 

--- a/regulations/templates/regulations/preamble-chrome.html
+++ b/regulations/templates/regulations/preamble-chrome.html
@@ -1,0 +1,56 @@
+{% extends "regulations/chrome.html" %}
+{% load static from staticfiles %}
+{% load macros render_nested %}
+
+{% block title %}Preamble {{doc_number}}{% endblock %}
+
+{% block sidebar-icons %}
+<li><a href="#table-of-contents" id="menu-link" class="toc-nav-link current" title="Table of Contents"><span class="icon-text">Table of Contents</span><img src="{%static "regulations/img/table-of-contents.svg" %}"
+       class="drawer-toggle-icon" alt="Table of Contents toggle" /></a></li>
+{% endblock %}
+
+{% block wayfinding %}
+<span class="subpart">{{doc_number}}</span>
+<span id="active-title">Active Title</span>
+{% endblock %}
+
+{% block header-secondary %}
+<span class="effective-date"><strong>Published Date:</strong> A Date</span>
+{% endblock %}
+
+{% block whole-toc %}
+<div id="menu" class="panel">
+  <div class="toc-drawer toc-container current hidden diff-toc" id="table-of-contents">
+    <div class="drawer-header">
+      <h3 class="toc-type">Table of Contents</h3>
+    </div><!-- /.drawer-header -->
+    <nav id="toc" class="regulation-nav drawer-content" role="navigation">
+      <ol>
+        {% for child in preamble.children %}
+          {% if child.title %}
+            <li>
+              <a href="{% url "chrome_preamble" paragraphs=child.label|join:"/" %}">{{child.title}}</a>
+            </li>
+            {% for subchild in child.children %}
+              {% if subchild.title %}
+                <li><a href="{% url "chrome_preamble" paragraphs=subchild.label|join:"/" %}"
+                       style="padding-left: 2em;">{{subchild.title}}</a></li>
+              {% endif %}
+            {% endfor %}
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </nav>
+  </div>
+</div> <!-- /.panel -->
+{% endblock %}
+
+{% block chrome-content %}
+<main role="main">
+  <div id="content-body" class="main-content">
+    {% render_nested template=sub_template context=sub_context %}
+  </div> <!-- /.main-content -->
+</main>
+{% endblock %}
+
+{% block chrome-sidebar %}{% endblock %}

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -69,3 +69,12 @@ class PreambleViewTests(TestCase):
         self.assertRaises(Http404, view,
                           RequestFactory().get('/preamble/1/c/x'),
                           paragraphs='1/c/x')
+
+    @patch('regulations.views.preamble.ApiReader')
+    def test_get_subtree_404(self, ApiReader):
+        """When a requested _subtree_ is not present, we should 404"""
+        ApiReader.return_value.preamble.return_value = self._mock_preamble
+        view = preamble.PreambleView.as_view()
+        self.assertRaises(Http404, view,
+                          RequestFactory().get('/preamble/1/not/here'),
+                          paragraphs='1/not/here')

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from django.http import Http404
 from django.test import RequestFactory
 from mock import patch
 
@@ -59,3 +60,12 @@ class PreambleViewTests(TestCase):
         response = view(request, paragraphs='1/c/x')
         self.assertNotIn('sub_context', response.context_data)
         self.assertEqual(response.context_data['node']['text'], '4')
+
+    @patch('regulations.views.preamble.ApiReader')
+    def test_get_404(self, ApiReader):
+        """When a requested doc is not present, we should return a 404"""
+        ApiReader.return_value.preamble.return_value = None
+        view = preamble.PreambleView.as_view()
+        self.assertRaises(Http404, view,
+                          RequestFactory().get('/preamble/1/c/x'),
+                          paragraphs='1/c/x')

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -7,15 +7,13 @@ from regulations.views import preamble
 
 
 class PreambleViewTests(TestCase):
-    _mock_preamble = {
-        'text': '1', 'label': ['1'], 'children': [
-            {'text': '2', 'label': ['1', 'c'], 'children': [
-                {'text': '3', 'label': ['1', 'c', 'i'], 'children': []},
-                {'text': '4', 'label': ['1', 'c', 'x'], 'children': []}
-            ]},
-            {'text': '5', 'label': ['1', '1'], 'children': []}
-        ]
-    }
+    _mock_preamble = dict(text='1', label=['1'], node_type='', children=[
+        dict(text='2', label=['1', 'c'], node_type='', children=[
+            dict(text='3', label=['1', 'c', 'i'], node_type='', children=[]),
+            dict(text='4', label=['1', 'c', 'x'], node_type='', children=[])
+        ]),
+        dict(text='5', label=['1', '1'], node_type='', children=[])
+    ])
 
     def test_find_subtree(self):
         """When a node is present in a tree, we should be able to find it.

--- a/regulations/tests/views_preamble_tests.py
+++ b/regulations/tests/views_preamble_tests.py
@@ -1,0 +1,63 @@
+from unittest import TestCase
+
+from django.test import RequestFactory
+from mock import patch
+
+from regulations.views import preamble
+
+
+class PreambleViewTests(TestCase):
+    _mock_preamble = {
+        'text': '1', 'label': ['1'], 'children': [
+            {'text': '2', 'label': ['1', 'c'], 'children': [
+                {'text': '3', 'label': ['1', 'c', 'i'], 'children': []},
+                {'text': '4', 'label': ['1', 'c', 'x'], 'children': []}
+            ]},
+            {'text': '5', 'label': ['1', '1'], 'children': []}
+        ]
+    }
+
+    def test_find_subtree(self):
+        """When a node is present in a tree, we should be able to find it.
+        When it is not, we should get None"""
+        root = self._mock_preamble
+        fn = preamble.find_subtree
+        self.assertEqual(fn(root, ['1'])['text'], '1')
+        self.assertEqual(fn(root, ['1', 'c'])['text'], '2')
+        self.assertEqual(fn(root, ['1', 'c', 'i'])['text'], '3')
+        self.assertEqual(fn(root, ['1', 'c', 'x'])['text'], '4')
+        self.assertEqual(fn(root, ['1', '1'])['text'], '5')
+        self.assertIsNone(fn(root, ['2']))
+        self.assertIsNone(fn(root, ['1', '2']))
+        self.assertIsNone(fn(root, ['1', 'c', 'r']))
+        self.assertIsNone(fn(root, ['1', 'c', 'i', 'r']))
+
+    @patch('regulations.views.preamble.ApiReader')
+    def test_get_integration(self, ApiReader):
+        """Verify that the contexts are built correctly before being sent to
+        the template. AJAX/partial=true requests should only get the inner
+        context (i.e. no UI-related context)"""
+        ApiReader.return_value.preamble.return_value = self._mock_preamble
+        view = preamble.PreambleView.as_view()
+
+        response = view(RequestFactory().get('/preamble/1/c/x'),
+                        paragraphs='1/c/x')
+        self.assertEqual(
+            response.context_data['sub_context']['node']['text'], '4')
+        self.assertEqual(
+            response.context_data['sub_context']['node']['children'], [])
+        self.assertEqual(response.context_data['preamble'],
+                         self._mock_preamble)
+        self.assertNotIn('node', response.context_data)
+
+        response = view(RequestFactory().get('/preamble/1/c/x?partial=true'),
+                        paragraphs='1/c/x')
+        self.assertNotIn('sub_context', response.context_data)
+        self.assertEqual(response.context_data['node']['text'], '4')
+
+        request = RequestFactory().get(
+            '/preamble/1/c/x',
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        response = view(request, paragraphs='1/c/x')
+        self.assertNotIn('sub_context', response.context_data)
+        self.assertEqual(response.context_data['node']['text'], '4')

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -16,6 +16,7 @@ from regulations.views.partial import PartialRegulationView, PartialSectionView
 from regulations.views import partial_interp
 from regulations.views.partial_search import PartialSearch
 from regulations.views.partial_sxs import ParagraphSXSView
+from regulations.views.preamble import PreambleView
 from regulations.views.redirect import diff_redirect, redirect_by_date
 from regulations.views.redirect import redirect_by_date_get
 from regulations.views.sidebar import SideBarView
@@ -66,6 +67,10 @@ urlpatterns = patterns(
         (section_pattern, version_pattern, newer_version_pattern),
         lt_cache(ChromeSectionDiffView.as_view()),
         name='chrome_section_diff_view'),
+
+    url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
+        PreambleView.as_view(), name='chrome_preamble'),
+
     # Redirect to version by date
     # Example: http://.../201-3-v/1999/11/8
     url(r'^%s/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})$'

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -43,6 +43,9 @@ class PreambleView(View):
             raise Http404
 
         subtree = find_subtree(preamble, label_parts)
+        if subtree is None:
+            raise Http404
+
         context = generate_html_tree(subtree)
         template = context['node']['template_name']
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -1,0 +1,52 @@
+from django.template.response import TemplateResponse
+from django.views.generic.base import View
+
+from regulations.generator.api_reader import ApiReader
+from regulations.generator.generator import LayerCreator
+from regulations.generator.html_builder import HTMLBuilder
+
+
+def find_subtree(root, label_parts):
+    """Given a nested tree and a label to look for, find the associated node
+    in the tree. Note that, unlike regulations, preamble trees _always_ encode
+    their exact position in the tree."""
+    cursor = root
+    while cursor and cursor['label'] != label_parts:
+        next_cursor = None
+        for child in cursor['children']:
+            if child['label'] == label_parts[:len(child['label'])]:
+                next_cursor = child
+        cursor = next_cursor
+    return cursor
+
+
+def generate_html_tree(subtree):
+    """Use the HTMLBuilder to generate a version of this subtree with
+    appropriate markup. Currently, includes no layers"""
+    builder = HTMLBuilder(*LayerCreator().get_appliers())
+    builder.tree = subtree
+    builder.generate_html()
+
+    return {'node': builder.tree,
+            'markup_page_type': 'reg-section'}
+
+
+class PreambleView(View):
+    """Displays either a notice preamble (or a subtree of that preamble). If
+    using AJAX or specifically requesting, generate only the preamble markup;
+    otherwise wrap it in the appropriate "chrome" """
+    def get(self, request, *args, **kwargs):
+        label_parts = kwargs.get('paragraphs', '').split('/')
+        preamble = ApiReader().preamble(label_parts[0])
+
+        subtree = find_subtree(preamble, label_parts)
+        context = generate_html_tree(subtree)
+        template = context['node']['template_name']
+
+        if not request.is_ajax() and request.GET.get('partial') != 'true':
+            # Wrap the inner context
+            context = {'sub_context': context, 'sub_template': template,
+                       'preamble': preamble}
+            template = 'regulations/preamble-chrome.html'
+        return TemplateResponse(request=request, template=template,
+                                context=context)

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.template.response import TemplateResponse
 from django.views.generic.base import View
 
@@ -38,6 +39,8 @@ class PreambleView(View):
     def get(self, request, *args, **kwargs):
         label_parts = kwargs.get('paragraphs', '').split('/')
         preamble = ApiReader().preamble(label_parts[0])
+        if preamble is None:
+            raise Http404
 
         subtree = find_subtree(preamble, label_parts)
         context = generate_html_tree(subtree)


### PR DESCRIPTION
Preambles are (currently) an idealized tree structure. They don't carry nearly
as much baggage as regulation data, which means we're free to write idealized
versions of the interface we'd be using in regulations. When we can, we'll
backport these designs.

In this case, we're breaking from the regulation UI by:

* Using a single view to represent "partial" and "chrome" views. Partial views
  are used when making an AJAX request or adding "&partial=true" to the url
* Using "sub_context"/"sub_template" rather than attempting to render the
  sub-content via a mock request
* Use an idealized subtree finding function. As a node label encodes its
  location for preambles, we can find subtrees in log(n) time
* Rather than use a dash-separated url arg like "111-22-a-3-ii", use slashes.
  /preamble/2016_111/ is the parent of /preamble/2016_111/p3, which is the
  parent of preamble/2016_111/p3/p0 and so forth

Still have some annoyances though:

* The presence of HTMLBuilder is like a magic incantation here. It's not at
  all clear what it does or how to call it
* There's an inline style for indenting the TOC. I figure we'll remove when we
  know better what it should look like.

Looks like:
<img width="1258" alt="screen shot 2016-03-11 at 12 13 25 am" src="https://cloud.githubusercontent.com/assets/326918/13693921/321867c0-e71e-11e5-8aa7-96c3dd3fb269.png">
<img width="1265" alt="screen shot 2016-03-11 at 12 13 41 am" src="https://cloud.githubusercontent.com/assets/326918/13693925/384f07e8-e71e-11e5-8d1d-772421e6b568.png">
<img width="1260" alt="screen shot 2016-03-11 at 12 13 52 am" src="https://cloud.githubusercontent.com/assets/326918/13693926/3cf34c0a-e71e-11e5-8620-fd3309eb21d3.png">
<img width="1262" alt="screen shot 2016-03-11 at 12 14 03 am" src="https://cloud.githubusercontent.com/assets/326918/13693927/412d8ac4-e71e-11e5-8931-3da33ff03437.png">

For eregs/notice-and-comment#14