### PR TITLE
Refresh footer on child render.

### DIFF
--- a/regulations/static/regulations/js/source/views/main/main-view.js
+++ b/regulations/static/regulations/js/source/views/main/main-view.js
@@ -213,11 +213,14 @@ var MainView = Backbone.View.extend({
     render: function(html, options) {
         var offsetTop, $scrollToId;
 
-        if (typeof this.childView !== 'undefined') {
-            this.sectionFooter.remove();
-        }
-
         this.$el.html(html);
+
+        // Destroy and recreate footer
+        this.sectionFooter.remove();
+        var $footer = this.$el.find('.section-nav');
+        if ($footer) {
+            this.sectionFooter = new SectionFooter({el: $footer});
+        }
 
         MainEvents.trigger('section:rendered');
 


### PR DESCRIPTION
Re-rendering the child view clears the markup for the main section,
including the section footer. Since the footer view is not recreated,
click listeners for the previous and next links aren't rebound. This
patch refreshes the section view when the main view renders a child.

[Resolves #122]