### PR TITLE
Instrument all source files for coverage.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,11 +119,16 @@ module.exports = function(grunt) {
 
     mocha_istanbul: {
       coverage: {
-        src: ['<%= env.frontEndPath %>/js/unittests/specs/**/*'],
+        src: ['<%= env.frontEndPath %>/js/unittests/specs/**/*.js'],
         options: {
-          mask:'*-spec.js',
+          root: '<%= env.frontEndPath %>/js',
+          istanbulOptions: ['--include-all-sources'],
           coverageFolder: '<%= env.frontEndPath %>/js/unittests/coverage',
-          excludes: ['<%= env.frontEndPath %>/js/unittests/specs/*'],
+          excludes: [
+            'built/**/*',
+            'unittests/**/*',
+            'source/otherlibs/**/*'
+          ],
           coverage: false
         }
       }


### PR DESCRIPTION
By default, istanbul only instruments `require`-d source files for test
coverage, which can yield inaccurately high coverage scores. This patch
passes the `--include-all-sources` flag to istanbul so that all relevant
source files are instrumented for coverage.

Since our unit tests only cover models, and since a lot of our code lives in views, this patch drops coverage from an implausible ~95% to 10-20% (depending on which coverage metrics we look at).