### PR TITLE
Skip pypy tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - '3.3'
     - '3.4'
     - '3.5'
-    - 'pypy'
 env:
     global:
         - secure: KUZAbAiGyBfiCePYo0MJVpu4YgWvYsPVxrhMOmN3vyEP2O1PpMcFJR/ESyK9mDCJ4Xck5Fc3sDfjRCDW2N6AdVPe313ERIAUxHEw9wFoeRuYl/0B/31KMSO/IjHmHwc1wW2vgtlLP/P3pa3vwr1jsJAhcrF3FBw0EnW5sz7OZQY=

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy
+envlist = py27,py33,py34,py35
 
 [testenv]
 deps =


### PR DESCRIPTION
Tests under pypy currently fail probabilistically. Since running under
pypy isn't a priority, this patch drops pypy from the list of test
environments.