### PR TITLE
Display preamble layers

### DIFF
--- a/regulations/generator/api_reader.py
+++ b/regulations/generator/api_reader.py
@@ -75,15 +75,18 @@ class ApiReader(object):
             self.cache.set(cache_key, element)
             return element
 
-    def layer(self, layer_name, doc_type, doc_id):
+    def layer(self, layer_name, doc_type, label_id, version=None):
         """When retrieving layer data, we cheat a bit -- we always retrieve
         layer data corresponding to the "root" of the document, rather than
-        only a subnode"""
-        doc_id_parts = doc_id.split('/')
-        doc_id_parts[-1] = doc_id_parts[-1].split('-')[0]   # root
-        doc_id = '/'.join(doc_id_parts)
+        only a subnode. We also must convert to the API format, where any
+        version information is prefixed to doc_id"""
+        root = label_id.split('-')[0]
+        if version is None:
+            doc_id = root
+        else:
+            doc_id = '{}/{}'.format(version, root)
         return self._get(
-            ('layer', layer_name, doc_type, ':'.join(doc_id_parts)),
+            ('layer', layer_name, doc_type, root, str(version)),
             'layer/{}/{}/{}'.format(layer_name, doc_type, doc_id))
 
     def diff(self, label, older, newer):

--- a/regulations/generator/api_reader.py
+++ b/regulations/generator/api_reader.py
@@ -75,11 +75,16 @@ class ApiReader(object):
             self.cache.set(cache_key, element)
             return element
 
-    def layer(self, layer_name, label, version):
-        regulation_part = label.split('-')[0]
+    def layer(self, layer_name, doc_type, doc_id):
+        """When retrieving layer data, we cheat a bit -- we always retrieve
+        layer data corresponding to the "root" of the document, rather than
+        only a subnode"""
+        doc_id_parts = doc_id.split('/')
+        doc_id_parts[-1] = doc_id_parts[-1].split('-')[0]   # root
+        doc_id = '/'.join(doc_id_parts)
         return self._get(
-            ['layer', layer_name, regulation_part, version],
-            'layer/%s/%s/%s' % (layer_name, regulation_part, version))
+            ('layer', layer_name, doc_type, ':'.join(doc_id_parts)),
+            'layer/{}/{}/{}'.format(layer_name, doc_type, doc_id))
 
     def diff(self, label, older, newer):
         """ End point for diffs. """

--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -104,7 +104,7 @@ class DiffLayerCreator(LayerCreator):
         to one of the versions we're comparing. This data is then combined
         before displaying"""
         older_layer = self.api.layer(layer_name, doc_type, doc_id)
-        newer_doc_id = '/'.join(self.newer_version, doc_id.split('/')[1:])
+        newer_doc_id = '/'.join([self.newer_version] + doc_id.split('/')[1:])
         newer_layer = self.api.layer(layer_name, doc_type, newer_doc_id)
 
         layer_json = dict(newer_layer)  # copy

--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -41,28 +41,6 @@ class LayerCreator(object):
         """ Hit the API to retrieve the regulation JSON. """
         return self.api.layer(api_name, regulation, version)
 
-    def add_layer(self, layer_name, regulation, version, sectional=False):
-        """ Add a normal layer (no special handling required) to the applier.
-        """
-
-        if layer_name.lower() in LayerCreator.LAYERS:
-            layer_class = LayerCreator.LAYERS[layer_name]
-            api_name = layer_class.data_source
-            applier_type = layer_class.layer_type
-            layer_json = self.get_layer_json(api_name, regulation, version)
-            if layer_json is None:
-                logging.warning("No data for %s/%s/%s"
-                                % (api_name, regulation, version))
-            else:
-                layer = layer_class(layer_json)
-
-                if sectional and hasattr(layer, 'sectional'):
-                    layer.sectional = sectional
-                if hasattr(layer, 'version'):
-                    layer.version = version
-
-                self.appliers[applier_type].add_layer(layer)
-
     def add_layers(self, layer_names, regulation, version, sectional=False):
         """Request a list of layers. As this might spawn multiple HTTP
         requests, we wrap the requests in threads so they can proceed

--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -37,14 +37,18 @@ class LayerCreator(object):
 
         self.api = api_reader.ApiReader()
 
-    def get_layer_json(self, api_name, regulation, version):
+    def get_layer_json(self, layer_name, doc_type, doc_id):
         """ Hit the API to retrieve the regulation JSON. """
-        return self.api.layer(api_name, regulation, version)
+        return self.api.layer(layer_name, doc_type, doc_id)
 
-    def add_layers(self, layer_names, regulation, version, sectional=False):
+    def add_layers(self, layer_names, doc_type, doc_id, sectional=False):
         """Request a list of layers. As this might spawn multiple HTTP
         requests, we wrap the requests in threads so they can proceed
         concurrently."""
+        if '/' in doc_id:   # @todo - is there a clean way to avoid this?
+            version = doc_id.split('/')[0]
+        else:
+            version = None
         # This doesn't deal with sectional interpretations yet.
         # we'll have to do that.
         layer_names = set(l for l in layer_names
@@ -56,7 +60,7 @@ class LayerCreator(object):
             layer_class = LayerCreator.LAYERS[layer_name]
             api_name = layer_class.data_source
             applier_type = layer_class.layer_type
-            layer_json = self.get_layer_json(api_name, regulation, version)
+            layer_json = self.get_layer_json(api_name, doc_type, doc_id)
             results.append((api_name, applier_type, layer_class, layer_json))
 
         #   Spawn threads
@@ -71,8 +75,8 @@ class LayerCreator(object):
 
         for api_name, applier_type, layer_class, layer_json in results:
             if layer_json is None:
-                logging.warning("No data for %s/%s/%s"
-                                % (api_name, regulation, version))
+                logging.warning("No data for %s/%s/%s", api_name, doc_type,
+                                doc_id)
             else:
                 layer = layer_class(layer_json)
 
@@ -95,12 +99,13 @@ class DiffLayerCreator(LayerCreator):
         super(DiffLayerCreator, self).__init__()
         self.newer_version = newer_version
 
-    def get_layer_json(self, api_name, label_id, version):
+    def get_layer_json(self, layer_name, doc_type, doc_id):
         """Diffs contain layer data from _two_ documents, each corresponding
         to one of the versions we're comparing. This data is then combined
         before displaying"""
-        older_layer = self.api.layer(api_name, label_id, version)
-        newer_layer = self.api.layer(api_name, label_id, self.newer_version)
+        older_layer = self.api.layer(layer_name, doc_type, doc_id)
+        newer_doc_id = '/'.join(self.newer_version, doc_id.split('/')[1:])
+        newer_layer = self.api.layer(layer_name, doc_type, newer_doc_id)
 
         layer_json = dict(newer_layer)  # copy
         layer_json.update(older_layer)  # older layer takes precedence

--- a/regulations/generator/generator.py
+++ b/regulations/generator/generator.py
@@ -95,27 +95,15 @@ class DiffLayerCreator(LayerCreator):
         super(DiffLayerCreator, self).__init__()
         self.newer_version = newer_version
 
-    @staticmethod
-    def combine_layer_versions(older_layer, newer_layer):
-        """ Create a new layer by taking all the nodes from the older
-        layer, and adding to the all the new nodes from the newer layer. """
+    def get_layer_json(self, api_name, label_id, version):
+        """Diffs contain layer data from _two_ documents, each corresponding
+        to one of the versions we're comparing. This data is then combined
+        before displaying"""
+        older_layer = self.api.layer(api_name, label_id, version)
+        newer_layer = self.api.layer(api_name, label_id, self.newer_version)
 
-        combined_layer = {}
-
-        for n in older_layer:
-            combined_layer[n] = older_layer[n]
-
-        for n in newer_layer:
-            if n not in combined_layer:
-                combined_layer[n] = newer_layer[n]
-
-        return combined_layer
-
-    def get_layer_json(self, api_name, regulation, version):
-        older_layer = self.api.layer(api_name, regulation, version)
-        newer_layer = self.api.layer(api_name, regulation, self.newer_version)
-
-        layer_json = self.combine_layer_versions(older_layer, newer_layer)
+        layer_json = dict(newer_layer)  # copy
+        layer_json.update(older_layer)  # older layer takes precedence
         return layer_json
 
 

--- a/regulations/generator/sidebar/analyses.py
+++ b/regulations/generator/sidebar/analyses.py
@@ -42,11 +42,10 @@ class Analyses(SidebarBase):
         """Retrieves SxSEntry data from the server"""
         if 'Interp' in self.label_id:
             reg_part = self.label_parts[0]
-            doc_id = '{}/{}-Interp'.format(self.version, reg_part)
-            data = http_client.layer('analyses', 'cfr', doc_id)
+            doc_id = reg_part + '-Interp'
         else:
-            doc_id = '{}/{}'.format(self.version, self.label_id)
-            data = http_client.layer('analyses', 'cfr', doc_id)
+            doc_id = self.label_id
+        data = http_client.layer('analyses', 'cfr', doc_id, self.version)
 
         return [
             SxSEntry(Label(label_id), doc_number=subdata[-1]['reference'][0])

--- a/regulations/generator/sidebar/analyses.py
+++ b/regulations/generator/sidebar/analyses.py
@@ -42,10 +42,11 @@ class Analyses(SidebarBase):
         """Retrieves SxSEntry data from the server"""
         if 'Interp' in self.label_id:
             reg_part = self.label_parts[0]
-            data = http_client.layer(
-                'analyses', reg_part + '-Interp', self.version)
+            doc_id = '{}/{}-Interp'.format(self.version, reg_part)
+            data = http_client.layer('analyses', 'cfr', doc_id)
         else:
-            data = http_client.layer('analyses', self.label_id, self.version)
+            doc_id = '{}/{}'.format(self.version, self.label_id)
+            data = http_client.layer('analyses', 'cfr', doc_id)
 
         return [
             SxSEntry(Label(label_id), doc_number=subdata[-1]['reference'][0])

--- a/regulations/generator/toc.py
+++ b/regulations/generator/toc.py
@@ -9,7 +9,7 @@ from regulations.generator.api_reader import ApiReader
 def fetch_toc(reg_part, version, flatten=False):
     """Fetch the toc, transform it into a list usable by navigation, etc."""
     api = ApiReader()
-    toc = api.layer('toc', reg_part, version)
+    toc = api.layer('toc', 'cfr', version + '/' + reg_part)
 
     toc_list = []
     if reg_part in toc:

--- a/regulations/generator/toc.py
+++ b/regulations/generator/toc.py
@@ -9,7 +9,7 @@ from regulations.generator.api_reader import ApiReader
 def fetch_toc(reg_part, version, flatten=False):
     """Fetch the toc, transform it into a list usable by navigation, etc."""
     api = ApiReader()
-    toc = api.layer('toc', 'cfr', version + '/' + reg_part)
+    toc = api.layer('toc', 'cfr', reg_part, version)
 
     toc_list = []
     if reg_part in toc:

--- a/regulations/tests/api_reader_tests.py
+++ b/regulations/tests/api_reader_tests.py
@@ -25,28 +25,25 @@ class ClientTest(TestCase):
         reader = ApiReader()
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "label-here", "date-here"))
+            reader.layer("layer-here", "cfr", "version-here/label-here"))
         get = api_client.ApiClient.return_value.get
         self.assertEqual(1, get.call_count)
         param = api_client.ApiClient.return_value.get.call_args[0][0]
-        self.assertTrue('layer-here' in param)
-        self.assertTrue('label' in param)   # grabs the root
-        self.assertTrue('date-here' in param)
+        self.assertIn('layer-here/cfr/version-here/label', param)
+        self.assertNotIn('label-here', param)   # only grabs the root
 
         #   Cache
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "label-abc", "date-here"))
+            reader.layer("layer-here", "cfr", "version-here/label-abc"))
         self.assertEqual(1, get.call_count)
 
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "lablab", "date-here"))
+            reader.layer("layer-here", "cfr", "version-here/lablab"))
         self.assertEqual(2, get.call_count)
         param = get.call_args[0][0]
-        self.assertTrue('layer-here' in param)
-        self.assertTrue('lablab' in param)
-        self.assertTrue('date-here' in param)
+        self.assertIn('layer-here/cfr/version-here/lablab', param)
 
     @patch('regulations.generator.api_reader.api_client')
     def test_notices(self, api_client):

--- a/regulations/tests/api_reader_tests.py
+++ b/regulations/tests/api_reader_tests.py
@@ -25,25 +25,32 @@ class ClientTest(TestCase):
         reader = ApiReader()
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "cfr", "version-here/label-here"))
+            reader.layer("layer-here", "cfr", "label-here", "version-here"))
         get = api_client.ApiClient.return_value.get
         self.assertEqual(1, get.call_count)
         param = api_client.ApiClient.return_value.get.call_args[0][0]
         self.assertIn('layer-here/cfr/version-here/label', param)
-        self.assertNotIn('label-here', param)   # only grabs the root
+        self.assertNotIn('label-here', param)   # only grabs the root, "label"
 
         #   Cache
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "cfr", "version-here/label-abc"))
+            reader.layer("layer-here", "cfr", "label-abc", "version-here"))
         self.assertEqual(1, get.call_count)
 
         self.assertEqual(
             to_return,
-            reader.layer("layer-here", "cfr", "version-here/lablab"))
+            reader.layer("layer-here", "cfr", "lablab", "version-here"))
         self.assertEqual(2, get.call_count)
         param = get.call_args[0][0]
         self.assertIn('layer-here/cfr/version-here/lablab', param)
+
+        self.assertEqual(
+            to_return,
+            reader.layer("layer-here", "preamble", "lablab"))
+        self.assertEqual(3, get.call_count)
+        param = get.call_args[0][0]
+        self.assertIn('layer-here/preamble/lablab', param)
 
     @patch('regulations.generator.api_reader.api_client')
     def test_notices(self, api_client):

--- a/regulations/tests/generator_tests.py
+++ b/regulations/tests/generator_tests.py
@@ -105,7 +105,7 @@ class GeneratorTest(TestCase):
 
         creator = generator.LayerCreator()
         creator.add_layers(
-            ['meta', 'graphics', 'internal'], '205', 'verver',
+            ['meta', 'graphics', 'internal'], 'cfr', 'verver/205',
             sectional=True)
         i, p, s = creator.get_appliers()
         self.assertEquals(len(p.layers), 1)

--- a/regulations/tests/generator_tests.py
+++ b/regulations/tests/generator_tests.py
@@ -100,20 +100,6 @@ class GeneratorTest(TestCase):
         self.assertTrue(isinstance(s_applier, SearchReplaceLayersApplier))
 
     @patch('regulations.generator.generator.LayerCreator.get_layer_json')
-    def test_add_layer(self, get_layer_json):
-        get_layer_json.return_value = {'layer': 'layer'}
-        creator = generator.LayerCreator()
-        creator.add_layer('meta', '205', 'verver')
-        i, p, s = creator.get_appliers()
-        self.assertEquals(len(p.layers), 1)
-
-        get_layer_json.return_value = None
-        creator = generator.LayerCreator()
-        creator.add_layer('meta', '205', 'verver')
-        i, p, s = creator.get_appliers()
-        self.assertEquals(len(p.layers), 0)
-
-    @patch('regulations.generator.generator.LayerCreator.get_layer_json')
     def test_add_layers(self, get_layer_json):
         get_layer_json.return_value = {'layer': 'layer'}
 

--- a/regulations/tests/generator_tests.py
+++ b/regulations/tests/generator_tests.py
@@ -105,8 +105,8 @@ class GeneratorTest(TestCase):
 
         creator = generator.LayerCreator()
         creator.add_layers(
-            ['meta', 'graphics', 'internal'], 'cfr', 'verver/205',
-            sectional=True)
+            ['meta', 'graphics', 'internal'], 'cfr', '205',
+            sectional=True, version='verver')
         i, p, s = creator.get_appliers()
         self.assertEquals(len(p.layers), 1)
         self.assertEquals(len(i.layers), 1)

--- a/regulations/views/chrome_breakaway.py
+++ b/regulations/views/chrome_breakaway.py
@@ -22,7 +22,7 @@ class ChromeBreakawayView(ChromeView):
         context['reg_part'] = context['label_id'].split('-')[0]
         context['version'] = self.request.GET.get('from_version')
         meta = api_reader.ApiReader().layer(
-            'meta', 'cfr', context['version'] + '/' + context['reg_part'])
+            'meta', 'cfr', context['reg_part'], context['version'])
         context['meta'] = meta[context['reg_part']][0]
         context['formatted_id'] = label_to_text(context['label_id'].split('-'))
 

--- a/regulations/views/chrome_breakaway.py
+++ b/regulations/views/chrome_breakaway.py
@@ -21,8 +21,8 @@ class ChromeBreakawayView(ChromeView):
 
         context['reg_part'] = context['label_id'].split('-')[0]
         context['version'] = self.request.GET.get('from_version')
-        meta = api_reader.ApiReader().layer('meta', context['reg_part'],
-                                            context['version'])
+        meta = api_reader.ApiReader().layer(
+            'meta', 'cfr', context['version'] + '/' + context['reg_part'])
         context['meta'] = meta[context['reg_part']][0]
         context['formatted_id'] = label_to_text(context['label_id'].split('-'))
 

--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -31,9 +31,10 @@ def get_appliers(label_id, versions):
         raise error_handling.MissingContentException()
 
     layer_creator = generator.DiffLayerCreator(versions.newer)
+    doc_id = versions.older + '/' + label_id
     layer_creator.add_layers(
         ['graphics', 'paragraph', 'keyterms', 'defined', 'formatting'],
-        label_id, versions.older)
+        'cfr', doc_id)
     return layer_creator.get_appliers() + (diff, )
 
 

--- a/regulations/views/diff.py
+++ b/regulations/views/diff.py
@@ -31,10 +31,9 @@ def get_appliers(label_id, versions):
         raise error_handling.MissingContentException()
 
     layer_creator = generator.DiffLayerCreator(versions.newer)
-    doc_id = versions.older + '/' + label_id
     layer_creator.add_layers(
         ['graphics', 'paragraph', 'keyterms', 'defined', 'formatting'],
-        'cfr', doc_id)
+        'cfr', label_id, version=versions.older)
     return layer_creator.get_appliers() + (diff, )
 
 

--- a/regulations/views/partial.py
+++ b/regulations/views/partial.py
@@ -25,9 +25,8 @@ class PartialView(TemplateView):
     def determine_appliers(self, label_id, version):
         """Figure out which layers to apply by checking the GET args"""
         layer_creator = generator.LayerCreator()
-        doc_id = version + '/' + label_id
         layer_creator.add_layers(utils.layer_names(self.request), 'cfr',
-                                 doc_id, self.sectional_links)
+                                 label_id, self.sectional_links, version)
         return layer_creator.get_appliers()
 
     def get_context_data(self, **kwargs):

--- a/regulations/views/partial.py
+++ b/regulations/views/partial.py
@@ -25,9 +25,9 @@ class PartialView(TemplateView):
     def determine_appliers(self, label_id, version):
         """Figure out which layers to apply by checking the GET args"""
         layer_creator = generator.LayerCreator()
-        layer_creator.add_layers(
-            utils.layer_names(self.request), label_id, version,
-            self.__class__.sectional_links)
+        doc_id = version + '/' + label_id
+        layer_creator.add_layers(utils.layer_names(self.request), 'cfr',
+                                 doc_id, self.sectional_links)
         return layer_creator.get_appliers()
 
     def get_context_data(self, **kwargs):

--- a/regulations/views/partial_interp.py
+++ b/regulations/views/partial_interp.py
@@ -18,10 +18,9 @@ class PartialInterpView(PartialView):
     def mk_appliers(root_label, version):
         """Function to generate a shared set of appliers"""
         layer_creator = generator.LayerCreator()
-        doc_id = version + '/' + root_label
         layer_creator.add_layers(
-            ['terms', 'internal', 'keyterms', 'paragraph'], 'cfr', doc_id,
-            sectional=True)
+            ['terms', 'internal', 'keyterms', 'paragraph'], 'cfr', root_label,
+            sectional=True, version=version)
         return layer_creator.get_appliers()
 
     def determine_appliers(self, label_id, version):

--- a/regulations/views/partial_interp.py
+++ b/regulations/views/partial_interp.py
@@ -18,9 +18,10 @@ class PartialInterpView(PartialView):
     def mk_appliers(root_label, version):
         """Function to generate a shared set of appliers"""
         layer_creator = generator.LayerCreator()
+        doc_id = version + '/' + root_label
         layer_creator.add_layers(
-            ['terms', 'internal', 'keyterms', 'paragraph'], root_label,
-            version, sectional=True)
+            ['terms', 'internal', 'keyterms', 'paragraph'], 'cfr', doc_id,
+            sectional=True)
         return layer_creator.get_appliers()
 
     def determine_appliers(self, label_id, version):

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -41,7 +41,7 @@ class ParagraphSXSView(TemplateView):
            visible from this regulation version.) Make them in descending
            order"""
         sxs_layer_data = api_reader.ApiReader().layer(
-            'analyses', 'cfr', version + '/' + label_id)
+            'analyses', 'cfr', label_id, version)
 
         if label_id not in sxs_layer_data:
             return []

--- a/regulations/views/partial_sxs.py
+++ b/regulations/views/partial_sxs.py
@@ -40,8 +40,8 @@ class ParagraphSXSView(TemplateView):
         """Grab other analyses for this same paragraph (limiting to those
            visible from this regulation version.) Make them in descending
            order"""
-        sxs_layer_data = api_reader.ApiReader().layer('analyses', label_id,
-                                                      version)
+        sxs_layer_data = api_reader.ApiReader().layer(
+            'analyses', 'cfr', version + '/' + label_id)
 
         if label_id not in sxs_layer_data:
             return []

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -5,6 +5,7 @@ from django.views.generic.base import View
 from regulations.generator.api_reader import ApiReader
 from regulations.generator.generator import LayerCreator
 from regulations.generator.html_builder import HTMLBuilder
+from regulations.views import utils
 
 
 def find_subtree(root, label_parts):
@@ -21,10 +22,14 @@ def find_subtree(root, label_parts):
     return cursor
 
 
-def generate_html_tree(subtree):
+def generate_html_tree(subtree, request):
     """Use the HTMLBuilder to generate a version of this subtree with
     appropriate markup. Currently, includes no layers"""
-    builder = HTMLBuilder(*LayerCreator().get_appliers())
+    layer_creator = LayerCreator()
+    doc_id = '-'.join(subtree['label'])
+    layer_creator.add_layers(utils.layer_names(request), 'preamble',
+                             doc_id, sectional=True)
+    builder = HTMLBuilder(*layer_creator.get_appliers())
     builder.tree = subtree
     builder.generate_html()
 
@@ -46,7 +51,7 @@ class PreambleView(View):
         if subtree is None:
             raise Http404
 
-        context = generate_html_tree(subtree)
+        context = generate_html_tree(subtree, request)
         template = context['node']['template_name']
 
         if not request.is_ajax() and request.GET.get('partial') != 'true':
@@ -68,7 +73,7 @@ class PrepareCommentView(View):
         if subtree is None:
             raise Http404
 
-        context = generate_html_tree(subtree)
+        context = generate_html_tree(subtree, request)
         context.update({
             'preamble': preamble,
         })

--- a/regulations/views/utils.py
+++ b/regulations/views/utils.py
@@ -26,8 +26,8 @@ def regulation_meta(regulation_part, version, sectional=False):
     """ Return the contents of the meta layer, without using a tree. """
 
     layer_manager = generator.LayerCreator()
-    doc_id = version + '/' + regulation_part
-    layer_manager.add_layers(['meta'], 'cfr', doc_id, sectional)
+    layer_manager.add_layers(['meta'], 'cfr', regulation_part, sectional,
+                             version)
 
     p_applier = layer_manager.appliers['paragraph']
     meta_layer = p_applier.layers[MetaLayer.shorthand]

--- a/regulations/views/utils.py
+++ b/regulations/views/utils.py
@@ -26,7 +26,8 @@ def regulation_meta(regulation_part, version, sectional=False):
     """ Return the contents of the meta layer, without using a tree. """
 
     layer_manager = generator.LayerCreator()
-    layer_manager.add_layers(['meta'], regulation_part, version, sectional)
+    doc_id = version + '/' + regulation_part
+    layer_manager.add_layers(['meta'], 'cfr', doc_id, sectional)
 
     p_applier = layer_manager.appliers['paragraph']
     meta_layer = p_applier.layers[MetaLayer.shorthand]

--- a/regulations/views/utils.py
+++ b/regulations/views/utils.py
@@ -26,8 +26,7 @@ def regulation_meta(regulation_part, version, sectional=False):
     """ Return the contents of the meta layer, without using a tree. """
 
     layer_manager = generator.LayerCreator()
-    layer_manager.add_layer(
-        MetaLayer.shorthand, regulation_part, version, sectional)
+    layer_manager.add_layers(['meta'], regulation_part, version, sectional)
 
     p_applier = layer_manager.appliers['paragraph']
     meta_layer = p_applier.layers[MetaLayer.shorthand]


### PR DESCRIPTION
This patch will allow layers (notably, graphics and formatting) relevant to preamble data to be displayed. It's a simple implementation which makes no distinction between different layer types for different documents (for example, it'll try checking for "interpretations" on preamble data).

To get there:
* Remove/rewrite unused functions
* Use the doc_type namespacing introduced in 18F/regulations-core#45 (a dependency)
* Add layer data when rendering the preamble

Should resolve eregs/notice-and-comment#19