### PR TITLE
Lazy load all images with the appropriate class

### DIFF
--- a/regulations/static/regulations/js/source/views/main/child-view.js
+++ b/regulations/static/regulations/js/source/views/main/child-view.js
@@ -58,6 +58,7 @@ var ChildView = Backbone.View.extend({
         this.activeSection = this.id;
         this.$activeSection = $('#' + this.activeSection);
 
+        this.loadImages();
         return this;
     },
 
@@ -77,6 +78,7 @@ var ChildView = Backbone.View.extend({
 
     render: function() {
         this.updateWayfinding();
+        this.loadImages();
         HeaderEvents.trigger('section:open', this.id);
         DrawerEvents.trigger('section:open', this.id);
     },
@@ -175,6 +177,11 @@ var ChildView = Backbone.View.extend({
         this.stopListening();
         this.off();
         return this;
+    },
+
+    // lazy load images as the user scrolls
+    loadImages: function() {
+        $('.reg-image').lazyload();
     }
 });
 

--- a/regulations/static/regulations/js/source/views/main/reg-view.js
+++ b/regulations/static/regulations/js/source/views/main/reg-view.js
@@ -58,8 +58,6 @@ var RegView = ChildView.extend({
         }
 
         ChildView.prototype.initialize.apply(this, arguments);
-
-        this.loadImages();
     },
 
     // only concerned with resetting DOM, no matter
@@ -176,8 +174,6 @@ var RegView = ChildView.extend({
         ChildView.prototype.render.apply(this, arguments);
 
         this.checkDefinitionScope();
-
-        this.loadImages();
     },
 
     // content section key term link click handler
@@ -285,11 +281,6 @@ var RegView = ChildView.extend({
             regVersion: version,
             type: 'inline-interp'
         });
-    },
-
-    // lazy load images as the user scrolls
-    loadImages: function() {
-        $('.reg-image').lazyload();
     }
 });
 


### PR DESCRIPTION
We had only been triggering the correct rendering of lazy-loaded images in
regulation text. We'd like to do that for _all_ primary content (including
diffs, preambles, etc.)