### PR TITLE
Show comment preview before submit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "backbone-query-parameters": "0.4.0",
     "clipboard": "1.5.5",
     "datatables.net": "1.10.10",
-    "jquery": "1.11.3",
+    "jquery": "1.12.2",
     "jquery-lazyload": "1.9.7",
     "jquery-scrollstop": "1.2.0",
     "prosemirror": "0.4.0",

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -10,19 +10,39 @@ var CommentEvents = require('../../events/comment-events');
 
 var CommentReviewView = Backbone.View.extend({
   events: {
-    'click .comment-review-submit': 'submit'
+    'click #preview-button': 'preview',
+    'click #submit-button': 'submit'
   },
 
   initialize: function(options) {
     Backbone.View.prototype.setElement.call(this, '#' + options.id);
-    this.template = _.template($('#comment-template').html());
+
     this.$content = this.$el.find('#comment');
+    this.$previewContent = this.$el.find('#preview-content');
+    this.$status = this.$el.find('#status');
+
+    this.template = _.template($('#comment-template').html());
     this.docNumber = this.$el.data('doc-number');
     this.prefix = 'comment:' + this.docNumber;
 
     this.listenTo(CommentEvents, 'comment:clear', this.clearComment);
+    this.listenTo(CommentEvents, 'comment:clear', this.previewMode);
+    this.listenTo(CommentEvents, 'comment:save', this.previewMode);
 
     this.showComments();
+    this.previewMode();
+  },
+
+  previewMode: function() {
+    $('#preview-button').show();
+    $('#preview-content').hide();
+    $('#submit-button').hide();
+  },
+
+  submitMode: function() {
+    $('#preview-button').hide();
+    $('#preview-content').show();
+    $('#submit-button').show();
   },
 
   render: function() {},
@@ -65,9 +85,9 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   checkForComments: function() {
-    if (this.comments.length <= 0) {
+    if (!this.comments.length) {
       $('#comment').html('<p>There are no comments to review or submit.</p>');
-      $('.comment-review-submit').remove();
+      $('#comment-confirm').remove();
     }
   },
 
@@ -86,6 +106,22 @@ var CommentReviewView = Backbone.View.extend({
     };
   },
 
+  preview: function() {
+    var prefix = window.APP_PREFIX || '/';
+    var $xhr = $.ajax({
+      type: 'POST',
+      url: prefix + 'comments/preview',
+      data: JSON.stringify(this.serialize()),
+      contentType: 'application/json'
+    });
+    $xhr.then(this.previewSuccess.bind(this));
+  },
+
+  previewSuccess: function(resp) {
+    this.$previewContent.text(resp);
+    this.submitMode();
+  },
+
   submit: function() {
     var prefix = window.APP_PREFIX || '/';
     var $xhr = $.ajax({
@@ -100,7 +136,7 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   submitSuccess: function(resp) {
-    // TODO(jmcarp) Figure out desired behavior
+    this.$status.text('Comment submitted').fadeIn();
   },
 
   submitError: function() {

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -10,16 +10,18 @@ var CommentEvents = require('../../events/comment-events');
 
 var CommentReviewView = Backbone.View.extend({
   events: {
-    'click #preview-button': 'preview',
-    'click #submit-button': 'submit'
+    'click .preview-button': 'preview',
+    'click .submit-button': 'submit'
   },
 
   initialize: function(options) {
     Backbone.View.prototype.setElement.call(this, '#' + options.id);
 
     this.$content = this.$el.find('#comment');
-    this.$previewContent = this.$el.find('#preview-content');
-    this.$status = this.$el.find('#status');
+    this.$previewContent = this.$el.find('.preview-content');
+    this.$previewButton = this.$el.find('.preview-button');
+    this.$submitButton = this.$el.find('.submit-button');
+    this.$status = this.$el.find('.status');
 
     this.template = _.template($('#comment-template').html());
     this.docNumber = this.$el.data('doc-number');
@@ -34,15 +36,15 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   previewMode: function() {
-    $('#preview-button').show();
-    $('#preview-content').hide();
-    $('#submit-button').hide();
+    this.$previewButton.show();
+    this.$previewContent.hide();
+    this.$submitButton.hide();
   },
 
   submitMode: function() {
-    $('#preview-button').hide();
-    $('#preview-content').show();
-    $('#submit-button').show();
+    this.$previewButton.hide();
+    this.$previewContent.show();
+    this.$submitButton.show();
   },
 
   render: function() {},

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -85,6 +85,7 @@ var CommentView = Backbone.View.extend({
 
   setStorage: function() {
     var payload = {
+      id: this.section,
       comment: this.editor.getContent('markdown'),
       files: this.$queued.find('.queue-item').map(function(idx, elm) {
         var $elm = $(elm);
@@ -151,6 +152,11 @@ var CommentView = Backbone.View.extend({
     window.localStorage.removeItem(this.key);
     this.load();
     CommentEvents.trigger('comment:clear', this.section);
+  },
+
+  remove: function() {
+    this.clear();
+    Backbone.View.prototype.remove.call(this);
   },
 
   save: function(e) {

--- a/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
@@ -61,6 +61,7 @@ describe('CommentView', function() {
     commentView.addQueueItem('6bc649', 'attachment.txt');
     commentView.setStorage();
     var payload = {
+      id: '2016_02479',
       comment: 'dislike',
       files: [
         {key: '6bc649', name: 'attachment.txt'}
@@ -79,6 +80,7 @@ describe('CommentView', function() {
 
   it('loads state from localstorage', function() {
     var payload = {
+      id: '2016_02479',
       comment: 'like',
       files: [
         {key: '6bc649', name: 'attachment.txt'}

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -53,10 +53,10 @@
       <h2>Review your comments</h2>
       <div id="comment"></div>
       <div id="comment-confirm">
-        <button id="preview-button">Preview your comment</button>
-        <pre id="preview-content"></pre>
-        <button id="submit-button">Submit your comment</button>
-        <div id="status"></div>
+        <button class="preview-button">Preview your comment</button>
+        <pre class="preview-content"></pre>
+        <button class="submit-button">Submit your comment</button>
+        <div class="status"></div>
       </div>
     </section>
   </div>

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -52,7 +52,12 @@
     <section id="comment-review" data-page-type="comment-review" data-doc-number="{{ doc_number }}">
       <h2>Review your comments</h2>
       <div id="comment"></div>
-      <button class="comment-review-submit">Submit your comment</button>
+      <div id="comment-confirm">
+        <button id="preview-button">Preview your comment</button>
+        <pre id="preview-content"></pre>
+        <button id="submit-button">Submit your comment</button>
+        <div id="status"></div>
+      </div>
     </section>
   </div>
 


### PR DESCRIPTION
[Resolves https://github.com/eregs/notice-and-comment/issues/40]

Add very basic comment preview. This just shows the comment preview in a `<pre>` tag to start with:

<img width="760" alt="screen shot 2016-03-24 at 7 14 52 pm" src="https://cloud.githubusercontent.com/assets/1633460/14033910/bce73c06-f1f4-11e5-858a-693710339286.png">

<img width="755" alt="screen shot 2016-03-24 at 7 14 56 pm" src="https://cloud.githubusercontent.com/assets/1633460/14033912/c291425a-f1f4-11e5-8590-203ab132d14e.png">
