### PR TITLE
Add command for S3 CORS configuration.

### DIFF
--- a/regulations/management/commands/setup_cors.py
+++ b/regulations/management/commands/setup_cors.py
@@ -1,0 +1,26 @@
+import boto3
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Set CORS rules on the Notice and Comment attachment bucket'
+
+    def handle(self, *args, **options):
+        session = boto3.Session(
+            aws_access_key_id=settings.ATTACHMENT_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.ATTACHMENT_SECRET_ACCESS_KEY,
+        )
+        s3 = session.client('s3')
+        s3.put_bucket_cors(
+            Bucket=settings.ATTACHMENT_BUCKET,
+            CORSConfiguration={
+                'CORSRules': [
+                    {
+                        'AllowedMethods': ['PUT'],
+                        'AllowedOrigins': ['*'],
+                        'AllowedHeaders': ['*'],
+                    },
+                ],
+            },
+        )

--- a/regulations/management/commands/setup_cors.py
+++ b/regulations/management/commands/setup_cors.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
                 'CORSRules': [
                     {
                         'AllowedMethods': ['PUT'],
-                        'AllowedOrigins': ['*'],
+                        'AllowedOrigins': settings.ALLOWED_HOSTS or ['*'],
                         'AllowedHeaders': ['*'],
                     },
                 ],


### PR DESCRIPTION
To be run on app startup or manually.

[Resolves #57]

Ping @cmc333333: I was thinking of having this run on app startup in `notice-and-comment`. It's redundant after the first run, unless the bucket gets cycled, but it's also fast, and I'd like to minimize manual deploy-related steps here. :+1: / :-1: ?