### PR TITLE
Add flags to customize front-end build.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -161,7 +161,7 @@ module.exports = function(grunt) {
     watch: {
       js: {
         files: ['Gruntfile.js', '<%= env.frontEndPath %>/js/source/**/*.js'],
-        tasks: ['eslint','browserify:dev']
+        tasks: ['eslint', 'browserify:dev']
       },
       css: {
         files: ['<%= env.frontEndPath %>/css/less/**/*.less'],
@@ -192,6 +192,7 @@ module.exports = function(grunt) {
   grunt.registerTask('nose', ['shell:nose-chrome', 'shell:nose-ie11']);
   grunt.registerTask('test', ['eslint', 'mocha_istanbul', 'nose']);
   grunt.registerTask('test-js', ['eslint', 'mocha_istanbul']);
-  grunt.registerTask('build', ['default', 'test-js']);
-  grunt.registerTask('default', ['copy', 'browserify', 'less', 'cssmin']);
+  grunt.registerTask('build-dev', ['copy', 'browserify:dev', 'less']);
+  grunt.registerTask('build-dist', ['copy', 'browserify:dist', 'less', 'cssmin']);
+  grunt.registerTask('default', ['build-dist']);
 };

--- a/frontendbuild.sh
+++ b/frontendbuild.sh
@@ -7,4 +7,4 @@ if [ ! -f config.json ]; then
 fi
 
 npm install
-grunt build
+grunt build-dist

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "engines": {
     "node": "4.4.0"
   },
-  "scripts": {
-    "postinstall": "grunt"
-  },
   "devDependencies": {
     "browserify": "^13.0.0",
     "browserify-shim": "^3.8.12",


### PR DESCRIPTION
* Add `--dev` flag to skip asset minification
* Add `--no-install` flag to skip npm install

These flags can be used for local development to quickly rebuild scripts
and styles, skipping unnecessary installs and minification steps. Note
that running `npm install` can take several seconds even when all
dependencies are already installed.

cc @xtine @cmc333333