### PR TITLE
54 show tracking number

### DIFF
--- a/regulations/management/commands/setup_cors.py
+++ b/regulations/management/commands/setup_cors.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
             CORSConfiguration={
                 'CORSRules': [
                     {
-                        'AllowedMethods': ['PUT'],
+                        'AllowedMethods': ['GET', 'PUT'],
                         'AllowedOrigins': settings.ALLOWED_HOSTS or ['*'],
                         'AllowedHeaders': ['*'],
                     },

--- a/regulations/static/regulations/js/source/views/comment/comment-review-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-review-view.js
@@ -121,11 +121,33 @@ var CommentReviewView = Backbone.View.extend({
   },
 
   submitSuccess: function(resp) {
-    this.$status.text('Comment submitted').fadeIn();
+    this.$status.text('Comment processing').fadeIn();
+    this.poll(resp.metadata_url);
   },
 
   submitError: function() {
     // TODO(jmcarp) Figure out desired behavior
+  },
+
+  poll: function(url) {
+    this.interval = window.setInterval(
+      function() {
+        $.getJSON(url).then(function(resp) {
+          window.clearInterval(this.interval);
+          this.setTrackingNumber(resp.trackingNumber);
+        }.bind(this));
+      }.bind(this),
+      5000
+    );
+  },
+
+  setTrackingNumber: function(number) {
+    this.$status.html(
+      '<div>Comment submitted</div>' +
+      '<div>Tracking number: ' +
+        '<a href="http://www.regulations.gov/#!searchResults;rpp=25;po=0;s=' + number + '">' + number + '</a>' +
+      '</div>'
+    );
   }
 });
 

--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -40,6 +40,17 @@ def submit_comment(body):
         )
         response.raise_for_status()
         logger.info(response.text)
+        return response.json()
+
+
+@shared_task
+def publish_metadata(response, key):
+    s3 = make_s3_client()
+    s3.put_object(
+        Body=response['trackingNumber'].encode(),
+        Bucket=settings.ATTACHMENT_BUCKET,
+        Key=key,
+    )
 
 
 def build_comment(body):
@@ -94,11 +105,15 @@ def fetch_file(path, key, name):
     whose content is downloaded from S3 where it is stored under ``key``
 
     '''
+    s3 = make_s3_client()
+    dest = os.path.join(path, name)
+    s3.download_file(settings.ATTACHMENT_BUCKET, key, dest)
+    return open(dest, "rb")
+
+
+def make_s3_client():
     session = boto3.Session(
         aws_access_key_id=settings.ATTACHMENT_ACCESS_KEY_ID,
         aws_secret_access_key=settings.ATTACHMENT_SECRET_ACCESS_KEY,
     )
-    s3 = session.client('s3')
-    dest = os.path.join(path, name)
-    s3.download_file(settings.ATTACHMENT_BUCKET, key, dest)
-    return open(dest, "rb")
+    return session.client('s3')

--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+import json
 import shutil
 import tempfile
 import contextlib
@@ -46,9 +47,11 @@ def submit_comment(body):
 @shared_task
 def publish_metadata(response, key):
     s3 = make_s3_client()
+    body = {'trackingNumber': response['trackingNumber']}
     s3.put_object(
-        Body=response['trackingNumber'].encode(),
+        Body=json.dumps(body).encode(),
         Bucket=settings.ATTACHMENT_BUCKET,
+        ContentType='application/json',
         Key=key,
     )
 

--- a/regulations/tests/views_comment_tests.py
+++ b/regulations/tests/views_comment_tests.py
@@ -12,7 +12,7 @@ from django.test import SimpleTestCase, override_settings
 )
 class TestUploadProxy(SimpleTestCase):
 
-    @mock.patch('regulations.views.comment.boto3.Session')
+    @mock.patch('regulations.tasks.boto3.Session')
     @mock.patch('regulations.views.comment.get_random_string')
     def test_get_url(self, get_random, session):
         client = session.return_value.client


### PR DESCRIPTION
![7ec1tjfi9s](https://cloud.githubusercontent.com/assets/1633460/14092613/3a994a80-f516-11e5-8638-8d288ec80b5d.gif)

On comment submit:
* Generate random submission ID
* Generate temporary URL for submission metadata
* Bind metadata ID to `publish_metadata` task
* Submit comment to regs.gov using `submit_comment` task
* Chain `submit_comment` to `publish_metadata` task
* Poll S3 key from client until it's not a 404

cc @cmc333333 @vrajmohan 