### PR TITLE
Upload progress

### DIFF
--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -175,6 +175,6 @@ a.comment-index-review {
   margin-bottom: 50px;
 }
 
-input.highlight[type="file"] {
+.comment input.highlight[type="file"] {
   background: blue;
 }

--- a/regulations/static/regulations/css/less/module/comment.less
+++ b/regulations/static/regulations/css/less/module/comment.less
@@ -174,3 +174,7 @@ a.comment-index-review {
 #comment-review {
   margin-bottom: 50px;
 }
+
+input.highlight[type="file"] {
+  background: blue;
+}

--- a/regulations/static/regulations/js/source/views/comment/attachment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/attachment-view.js
@@ -13,7 +13,7 @@ var AttachmentView = Backbone.View.extend({
   },
 
   initialize: function(options) {
-    this.template = _.template($('#comment-attachment-template').html());
+    this.template = _.template(document.querySelector('#comment-attachment-template').innerHTML);
     this.options = options;
 
     if (this.options.xhr) {
@@ -45,7 +45,7 @@ var AttachmentView = Backbone.View.extend({
     if (this.options.xhr) {
       this.options.xhr.abort();
     }
-  },
+  }
 });
 
 module.exports = AttachmentView;

--- a/regulations/static/regulations/js/source/views/comment/attachment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/attachment-view.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var $ = require('jquery');
+var _ = require('underscore');
+var Backbone = require('backbone');
+Backbone.$ = $;
+
+var CommentEvents = require('../../events/comment-events');
+
+var AttachmentView = Backbone.View.extend({
+  events: {
+    'click .attachment-remove': 'handleRemove'
+  },
+
+  initialize: function(options) {
+    this.template = _.template($('#comment-attachment-template').html());
+    this.options = options;
+
+    if (this.options.xhr) {
+      this.options.xhr.upload.addEventListener('progress', this.handleProgress.bind(this));
+      this.options.xhr.upload.addEventListener('load', this.handleLoad.bind(this));
+    }
+
+    this.render();
+    this.$progress = this.$el.find('.attachment-progress');
+  },
+
+  render: function() {
+    var $el = $(this.template(this.options));
+    this.options.$parent.append($el);
+    Backbone.View.prototype.setElement.call(this, $el);
+  },
+
+  handleProgress: function(e) {
+    var percent = e.loaded / e.total;
+    this.$progress.text(Math.round(percent * 1000) / 10);
+  },
+
+  handleLoad: function() {
+    this.$progress.empty();
+  },
+
+  handleRemove: function() {
+    CommentEvents.trigger('attachment:remove', this.options.key);
+    if (this.options.xhr) {
+      this.options.xhr.abort();
+    }
+  },
+});
+
+module.exports = AttachmentView;

--- a/regulations/static/regulations/js/source/views/comment/attachment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/attachment-view.js
@@ -28,7 +28,7 @@ var AttachmentView = Backbone.View.extend({
   render: function() {
     var $el = $(this.template(this.options));
     this.options.$parent.append($el);
-    Backbone.View.prototype.setElement.call(this, $el);
+    this.setElement($el);
   },
 
   handleProgress: function(e) {

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -11,32 +11,22 @@ require('prosemirror/dist/markdown');
 
 var CommentModel = require('../../models/comment-model');
 var CommentEvents = require('../../events/comment-events');
+var AttachmentView = require('../../views/comment/attachment-view');
 var comments = require('../../collections/comment-collection');
 
 function getUploadUrl(file) {
   var prefix = window.APP_PREFIX || '/';
   return $.getJSON(
     prefix + 'comments/attachment',
-    {size: file.size}
+    {size: file.size, type: file.type || 'application/octet-stream'}
   ).then(function(resp) {
     return resp;
   });
 }
 
-function readFile(file) {
-  var deferred = $.Deferred();
-  var reader = new FileReader();
-  reader.onload = function() {
-    deferred.resolve(reader.result);
-  };
-  reader.readAsBinaryString(file);
-  return deferred;
-}
-
 var CommentView = Backbone.View.extend({
   events: {
     'change input[type="file"]': 'addAttachment',
-    'click .queue-item': 'clearAttachment',
     'click .comment-clear': 'clear',
     'submit form': 'save'
   },
@@ -54,7 +44,10 @@ var CommentView = Backbone.View.extend({
       doc: ''
     });
 
+    this.attachmentViews = [];
+
     this.listenTo(CommentEvents, 'comment:target', this.target);
+    this.listenTo(CommentEvents, 'attachment:remove', this.clearAttachment);
 
     this.setSection(options.section);
   },
@@ -67,7 +60,6 @@ var CommentView = Backbone.View.extend({
       new CommentModel({id: section}) :
       comments.get(section) || new CommentModel({id: section});
     this.listenTo(this.model, 'destroy', this.setSection.bind(this, section, true));
-    this.listenTo(this.model, 'change', this.render);
     this.render();
   },
 
@@ -79,45 +71,39 @@ var CommentView = Backbone.View.extend({
     }
   },
 
-  addQueueItem: function(key, name) {
-    this.$queued.append(
-      $('<div class="queue-item" data-key="' + key + '">' + name + '</div>')
-    );
-  },
-
   render: function() {
     this.editor.setContent(this.model.get('comment'), 'markdown');
     this.$queued.empty();
-    _.each(this.model.get('files'), function(file) {
-      this.addQueueItem(file.key, file.name);
+    this.attachmentViews = this.model.get('files').map(function(file) {
+      return new AttachmentView(_.extend({$parent: this.$queued}, file));
     }.bind(this));
   },
 
   addAttachment: function(e) {
-    var key;
     var file = e.target.files[0];
     if (!file) { return; }
     getUploadUrl(file).then(function(url) {
-      key = url.key;
-      return readFile(file).then(function(data) {
-        return $.ajax({
-          type: 'PUT',
-          url: url.url,
-          data: data,
-          contentType: 'application/octet-stream',
-          processData: false
-        });
-      });
-    }).then(function(resp) {
-      this.addQueueItem(key, file.name);
-      $(e.target).val(null);
+      var xhr = new XMLHttpRequest();
+      this.attachmentViews.push(
+        new AttachmentView({
+          $parent: this.$queued,
+          name: file.name,
+          size: file.size,
+          key: url.key,
+          xhr: xhr
+        })
+      );
+      xhr.open('PUT', url.url);
+      xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+      xhr.send(file);
     }.bind(this));
   },
 
-  clearAttachment: function(e) {
-    var $target = $(e.target);
-    var key = $target.data('key');
-    $target.remove();
+  clearAttachment: function(key) {
+    var index = _.findIndex(this.attachmentViews, function(view) {
+      return view.options.key === key;
+    });
+    this.attachmentViews.splice(index, 1)[0].remove();
   },
 
   clear: function() {
@@ -128,13 +114,13 @@ var CommentView = Backbone.View.extend({
     e.preventDefault();
     this.model.set({
       comment: this.editor.getContent('markdown'),
-      files: this.$queued.find('.queue-item').map(function(idx, elm) {
-        var $elm = $(elm);
+      files: _.map(this.attachmentViews, function(view) {
         return {
-          key: $elm.data('key'),
-          name: $elm.text()
+          key: view.options.key,
+          name: view.options.name,
+          size: view.options.size
         };
-      }).get()
+      })
     });
     comments.add(this.model);
     this.model.save();

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -26,7 +26,9 @@ function getUploadUrl(file) {
 
 var CommentView = Backbone.View.extend({
   events: {
-    'change input[type="file"]': 'addAttachment',
+    'change input[type="file"]': 'addAttachments',
+    'dragenter input[type="file"]': 'highlightDropzone',
+    'dragleave input[type="file"]': 'unhighlightDropzone',
     'click .comment-clear': 'clear',
     'submit form': 'save'
   },
@@ -34,6 +36,7 @@ var CommentView = Backbone.View.extend({
   initialize: function(options) {
     this.$context = this.$el.find('.comment-context');
     this.$container = this.$el.find('.editor-container');
+    this.$input = this.$el.find('input[type="file"]');
     this.$queued = this.$el.find('.queued');
     this.$status = this.$el.find('.status');
 
@@ -79,9 +82,23 @@ var CommentView = Backbone.View.extend({
     }.bind(this));
   },
 
-  addAttachment: function(e) {
-    var file = e.target.files[0];
-    if (!file) { return; }
+  highlightDropzone: function() {
+    this.$input.addClass('highlight');
+  },
+
+  unhighlightDropzone: function() {
+    this.$input.removeClass('highlight');
+  },
+
+  addAttachments: function(e) {
+    _.each(e.target.files, function(file) {
+      this.addAttachment(file);
+    }.bind(this));
+    this.$input.val(null);
+    this.unhighlightDropzone();
+  },
+
+  addAttachment: function(file) {
     getUploadUrl(file).then(function(url) {
       var xhr = new XMLHttpRequest();
       this.attachmentViews.push(

--- a/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
+++ b/regulations/static/regulations/js/unittests/specs/views/comment-view-spec.js
@@ -28,7 +28,7 @@ describe('CommentView', function() {
       '<div class="comment">' +
         '<form>' +
           '<div class="editor-container"></div>' +
-          '<div class="queued"></div>' +
+          '<div class="comment-attachments"></div>' +
           '<input type="file">' +
           '<button type="submit">Save</button>' +
           '<div class="comment-clear">Clear</div>' +
@@ -59,7 +59,7 @@ describe('CommentView', function() {
   it('removes an attachment', function() {
     commentView.attachmentViews.push(
       new AttachmentView({
-        $parent: commentView.$queued,
+        $parent: commentView.$attachments,
         key: '6bc649',
         name: 'attachment.txt',
         size: 1234
@@ -104,6 +104,6 @@ describe('CommentView', function() {
     commentView.clear();
     expect(comments.get('2016_02479')).to.be.falsy;
     expect(commentView.editor.setContent).to.have.been.calledWith('', 'markdown');
-    expect(commentView.$queued.find('.queue-item').length).to.equal(0);
+    expect(commentView.$attachments.find('.queue-item').length).to.equal(0);
   });
 });

--- a/regulations/templates/regulations/comment-review-chrome.html
+++ b/regulations/templates/regulations/comment-review-chrome.html
@@ -67,7 +67,7 @@
         <h3><a href="<%= url %>" target="_blank"><%= title %></a></h3>
         <form>
           <div class="editor-container"></div>
-          <div class="queued"></div>
+          <div class="comment-attachments"></div>
           <input type="file">
           {# <button type="submit">Add to your comment</button> #}
           <div class="comment-clear">Remove this comment</div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -15,7 +15,7 @@
           <form>
             <div class="editor-container"></div>
             <div class="queued"></div>
-            <input type="file">
+            <input type="file" multiple>
             <button type="submit">Save</button>
             <div class="status"></div>
           </form>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -14,7 +14,7 @@
           <div class="comment-context"></div>
           <form>
             <div class="editor-container"></div>
-            <div class="queued"></div>
+            <div class="comment-attachments"></div>
             <input type="file" multiple>
             <button type="submit">Save</button>
             <div class="status"></div>

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -29,6 +29,15 @@
   </section>
 </section>
 
+<script id="comment-attachment-template" type="text/template">
+  <div>
+    <%= name %>
+    <%= size %>
+    <span class="attachment-remove">Remove</span>
+    <span class="attachment-progress"><span>
+  </div>
+</script>
+
 <script id="comment-index-template" type="text/template">
   <% _.each(comments, function(comment) { %>
     <li class="comment-index-item group" data-comment-section="<%= comment.id %>">

--- a/regulations/views/comment.py
+++ b/regulations/views/comment.py
@@ -28,7 +28,7 @@ def upload_proxy(request):
         ClientMethod='put_object',
         Params={
             'ContentLength': size,
-            'ContentType': 'application/octet-stream',
+            'ContentType': request.GET.get('type', 'application/octet-stream'),
             'Bucket': settings.ATTACHMENT_BUCKET,
             'Key': key,
         },


### PR DESCRIPTION
Add attachment upload progress, upload cancel / attachment delete, and draggable uploads. Still basically unstyled--if the behavior makes sense, I'll ask for help from @xtine and @donjo on that.

I was looking into using an external library like dropzone.js here, but I found myself writing almost as much code to integrate it as it took to implement with the html files api--dropzone and similar libraries are great at accepting files, but I had to fight with them to re-hydrate cached uploads from localstorage. So I opted to take the latter approach. Interested to hear whether @cmc333333 and @xtine agree--I'm not against refactoring to rely on dropzone if you all would prefer.

![35yb4ik0dq](https://cloud.githubusercontent.com/assets/1633460/14125601/1196493e-f5da-11e5-8aef-ccc71de3ecd1.gif)
