### PR TITLE
Replace --dev flag with settings.DEBUG_JS.

### DIFF
--- a/regulations/management/commands/compile_frontend.py
+++ b/regulations/management/commands/compile_frontend.py
@@ -34,10 +34,9 @@ class Command(BaseCommand):
     TARGET_DIR = "./compiled/regulations"
 
     def add_arguments(self, parser):
-        parser.add_argument('--dev', dest='dev', action='store_true')
         parser.add_argument('--no-install', dest='install',
                             action='store_false')
-        parser.set_defaults(dev=False, install=True)
+        parser.set_defaults(install=True)
 
     def find_regulations_directory(self):
         child = regulations.__file__
@@ -123,5 +122,5 @@ class Command(BaseCommand):
         self.remove_dirs()
         self.copy_configs()
         self.collect_files()
-        self.build_frontend(install=options['install'], dev=options['dev'])
+        self.build_frontend(install=options['install'], dev=settings.JS_DEBUG)
         self.cleanup()


### PR DESCRIPTION
We introduced a `--dev` flag to `compile_frontend` in 2bcb424, but this
flag should be coupled to the existing `DEBUG_JS` settings variable.
This patch reverts the `--dev` flag and uses `DEBUG_JS` in its place.
The `--no-install` flag is retained, since there isn't a corresponding
settings variable.

h/t @cmc333333 @tadgh-ohiggins @xtine