### PR TITLE
Explicitly set S3 signature version.

### DIFF
--- a/regulations/tasks.py
+++ b/regulations/tasks.py
@@ -7,6 +7,7 @@ import tempfile
 import contextlib
 
 import boto3
+from botocore.client import Config
 
 import requests
 from requests_toolbelt.multipart.encoder import MultipartEncoder
@@ -119,4 +120,4 @@ def make_s3_client():
         aws_access_key_id=settings.ATTACHMENT_ACCESS_KEY_ID,
         aws_secret_access_key=settings.ATTACHMENT_SECRET_ACCESS_KEY,
     )
-    return session.client('s3')
+    return session.client('s3', config=Config(signature_version='s3v4'))


### PR DESCRIPTION
Setting restrictions on file size via signed PUT requires the use of
S3V4 signatures. This patch explicitly sets the signature version on
creating the S3 client.

See http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html for
details. Thanks @vrajmohan for pointing out that length verification
wasn't working.