### PR TITLE
Veeeery rough first pass at CFR changes

### DIFF
--- a/regulations/templates/regulations/cfr_changes.html
+++ b/regulations/templates/regulations/cfr_changes.html
@@ -1,0 +1,9 @@
+{% for instruction in instructions %}
+  <div style="border: 1px solid black;">{{ instruction }}</div>
+{% endfor %}
+{% for authority in authorities %}
+<div><strong>Authority</strong>: {{ authority }}</div>
+{% endfor %}
+{% if tree %}{% with c=tree %}
+{% include "regulations/regulation_text.html" %}
+{% endwith %}{% endif %}

--- a/regulations/urls.py
+++ b/regulations/urls.py
@@ -16,7 +16,8 @@ from regulations.views.partial import PartialRegulationView, PartialSectionView
 from regulations.views import partial_interp
 from regulations.views.partial_search import PartialSearch
 from regulations.views.partial_sxs import ParagraphSXSView
-from regulations.views.preamble import PreambleView, PrepareCommentView
+from regulations.views.preamble import (
+    CFRChangesView, PreambleView, PrepareCommentView)
 from regulations.views.redirect import diff_redirect, redirect_by_date
 from regulations.views.redirect import redirect_by_date_get
 from regulations.views.sidebar import SideBarView
@@ -76,6 +77,8 @@ urlpatterns = patterns(
         lt_cache(ChromeSectionDiffView.as_view()),
         name='chrome_section_diff_view'),
 
+    url(r'^preamble/(?P<doc_number>[\w-]+)/cfr_changes/(?P<section>[\w-]+)$',
+        CFRChangesView.as_view(), name='cfr_changes'),
     url(r'^preamble/(?P<paragraphs>[-\w]+(/[-\w]+)*)$',
         PreambleView.as_view(), name='chrome_preamble'),
 

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -108,14 +108,16 @@ class CFRChangesView(View):
             request=request, template='regulations/cfr_changes.html',
             context=context)
 
-    def authorities_context(self, amendments, cfr_part):
+    @staticmethod
+    def authorities_context(amendments, cfr_part):
         """What authorities information is relevant to this CFR part?"""
         relevant = [amd for amd in amendments
                     if amd.get('cfr_part') == cfr_part and 'authority' in amd]
         return {'instructions': [a['instruction'] for a in relevant],
                 'authorities': [a['authority'] for a in relevant]}
 
-    def regtext_changes_context(self, amendments, version_info, label_id):
+    @staticmethod
+    def regtext_changes_context(amendments, version_info, label_id):
         """Generate diffs for the changed section"""
         cfr_part = label_id.split('-')[0]
         relevant = []

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -1,11 +1,15 @@
+from django.conf import settings
 from django.http import Http404
 from django.template.response import TemplateResponse
 from django.views.generic.base import View
 
 from regulations.generator.api_reader import ApiReader
 from regulations.generator.generator import LayerCreator
-from regulations.generator.html_builder import PreambleHTMLBuilder
+from regulations.generator.html_builder import (
+    CFRHTMLBuilder, PreambleHTMLBuilder)
+from regulations.generator.layers.utils import is_contained_in
 from regulations.views import utils
+from regulations.views.diff import Versions, get_appliers
 
 
 def find_subtree(root, label_parts):
@@ -84,3 +88,49 @@ class PrepareCommentView(View):
 
         return TemplateResponse(request=request, template=template,
                                 context=context)
+
+
+class CFRChangesView(View):
+    def get(self, request, doc_number, section):
+        cfr_changes = getattr(settings, 'CFR_CHANGES', {})  # mock
+        if doc_number not in cfr_changes:
+            raise Http404("Doc # {} not found".format(doc_number))
+        versions = cfr_changes[doc_number]["versions"]
+        amendments = cfr_changes[doc_number]["amendments"]
+        label_parts = section.split('-')
+
+        if len(label_parts) == 1:
+            context = self.authorities_context(amendments, cfr_part=section)
+        else:
+            context = self.regtext_changes_context(amendments, versions,
+                                                   label_id=section)
+        return TemplateResponse(
+            request=request, template='regulations/cfr_changes.html',
+            context=context)
+
+    def authorities_context(self, amendments, cfr_part):
+        """What authorities information is relevant to this CFR part?"""
+        relevant = [amd for amd in amendments
+                    if amd.get('cfr_part') == cfr_part and 'authority' in amd]
+        return {'instructions': [a['instruction'] for a in relevant],
+                'authorities': [a['authority'] for a in relevant]}
+
+    def regtext_changes_context(self, amendments, version_info, label_id):
+        """Generate diffs for the changed section"""
+        cfr_part = label_id.split('-')[0]
+        relevant = []
+        for amd in amendments:
+            keys = amd.get('changes', {}).keys()
+            if any(is_contained_in(key, label_id) for key in keys):
+                relevant.append(amd)
+
+        versions = Versions(version_info[cfr_part]['left'],
+                            version_info[cfr_part]['right'])
+        tree = ApiReader().regulation(label_id, versions.older)
+        appliers = get_appliers(label_id, versions)
+
+        builder = CFRHTMLBuilder(*appliers)
+        builder.tree = tree
+        builder.generate_html()
+        return {'instructions': [a['instruction'] for a in relevant],
+                'tree': builder.tree}


### PR DESCRIPTION
While we work on getting the data ready, here is a mock-data driven first stab
at displaying changes to the CFR (as described in a proposed or final rule).
No tests yet.

Resolves eregs/notice-and-comment#89 (though without the data).