### PR TITLE
Add resiliency to missing TOC/Meta data

### DIFF
--- a/regulations/generator/toc.py
+++ b/regulations/generator/toc.py
@@ -2,14 +2,20 @@
 the api. We need to modify it a bit to group subparts, subterps, etc. These
 modifications, then, are used for navigation, citations, and the TOC
 layer"""
-from regulations.generator import title_parsing
-from regulations.generator.api_reader import ApiReader
+import logging
+
+from regulations.generator import api_reader, title_parsing
+
+
+logger = logging.getLogger(__name__)
 
 
 def fetch_toc(reg_part, version, flatten=False):
     """Fetch the toc, transform it into a list usable by navigation, etc."""
-    api = ApiReader()
-    toc = api.layer('toc', 'cfr', reg_part, version)
+    toc = api_reader.ApiReader().layer('toc', 'cfr', reg_part, version)
+    if toc is None:
+        logger.warning("404 when fetching TOC for %s@%s", reg_part, version)
+        toc = []
 
     toc_list = []
     if reg_part in toc:

--- a/regulations/tests/generator_toc_tests.py
+++ b/regulations/tests/generator_toc_tests.py
@@ -1,6 +1,8 @@
 # vim: set fileencoding=utf-8
 from unittest import TestCase
 
+from mock import patch
+
 from regulations.generator import toc
 
 
@@ -153,3 +155,10 @@ class TocTest(TestCase):
         self.assertTrue(subpart.get('is_subterp'))
         self.assertEqual(['1001', 'Subpart', 'C', 'Interp'], subpart['index'])
         self.assertEqual('1001-Subpart-C-Interp', subpart['section_id'])
+
+    @patch('regulations.generator.toc.api_reader')
+    def test_fetch_toc_404(self, api_reader):
+        """Should not crash if there is no TOC data"""
+        api_reader.ApiReader.return_value.layer.return_value = None
+        self.assertEqual([], toc.fetch_toc('111', 'vvv'))
+        self.assertEqual([], toc.fetch_toc('111', 'vvv', True))

--- a/regulations/tests/views_utils_test.py
+++ b/regulations/tests/views_utils_test.py
@@ -53,3 +53,11 @@ class UtilsTest(TestCase):
         self.assertEqual(utils.make_sortable("abc123def456"),
                          ("abc", 123, "def", 456))
         self.assertEqual(utils.make_sortable("123abc456"), (123, "abc", 456))
+
+    @patch('regulations.views.utils.api_reader')
+    def test_regulation_meta_404(self, api_reader):
+        """We shouldn't crash if meta data isn't available"""
+        ret_vals = [None, {}, {'111-22': 'something'}]
+        for ret_val in ret_vals:
+            api_reader.ApiReader.return_value.layer.return_value = ret_val
+            self.assertEqual({}, utils.regulation_meta('111', 'vvv'))

--- a/regulations/views/chrome.py
+++ b/regulations/views/chrome.py
@@ -86,14 +86,10 @@ class ChromeView(TemplateView):
                     sub['index'], version, self.partial_class.sectional_links)
         context['TOC'] = toc
 
-        regulation_meta = utils.regulation_meta(
-            reg_part,
-            version,
-            self.partial_class.sectional_links)
+        context['meta'] = utils.regulation_meta(reg_part, version)
         context['version_switch_view'] = self.version_switch_view
         context['diff_redirect_label'] = self.diff_redirect_label(
             context['label_id'], toc)
-        context['meta'] = regulation_meta
 
     def get_context_data(self, **kwargs):
         context = super(ChromeView, self).get_context_data(**kwargs)

--- a/regulations/views/reg_landing.py
+++ b/regulations/views/reg_landing.py
@@ -41,11 +41,8 @@ def regulation(request, label_id):
         label_id, current_version['version'])
     context['reg_part'] = label_id.split('-')[0]
 
-    regulation_meta = utils.regulation_meta(
-        label_id,
-        current_version['version'],
-        True)
-    context['meta'] = regulation_meta
+    context['meta'] = utils.regulation_meta(label_id,
+                                            current_version['version'])
 
     c = RequestContext(request, context)
 

--- a/regulations/views/universal_landing.py
+++ b/regulations/views/universal_landing.py
@@ -26,7 +26,7 @@ def get_regulations_list(all_versions):
 
     for part in reg_parts:
         version = all_versions[part][0]['version']
-        reg_meta = utils.regulation_meta(part, version, True)
+        reg_meta = utils.regulation_meta(part, version)
         first_section = utils.first_section(part, version)
         amendments = filter_future_amendments(all_versions.get(part, None))
 


### PR DESCRIPTION
Previously, we had more or less hard-coded the existence of TOC/meta data for
a given regulation. This bites us when the reg or version doesn't exist --
while later code will correctly 404, the initial chrome-building steps were
crashing.

Also makes the `regulation_meta` function a bit easier to read.

Resolves #161 