### PR TITLE
Miscellaneous PDF cleanups.

### DIFF
--- a/regulations/settings/base.py
+++ b/regulations/settings/base.py
@@ -103,14 +103,6 @@ TEMPLATES = [
             ],
         }
     },
-    {
-        "BACKEND": "django.template.backends.jinja2.Jinja2",
-        "APP_DIRS": True,
-        "OPTIONS": {
-            "trim_blocks": True,
-            "lstrip_blocks": True,
-        },
-    },
 ]
 
 

--- a/regulations/templates/regulations/comment.md
+++ b/regulations/templates/regulations/comment.md
@@ -1,10 +1,13 @@
 {% for section in sections %}
-# {{section.id}}
+# {{section.label}}
 {{section.comment}}
 {% if section.files %}
 ## Attachments
 {% for file in section.files %}
 * {{file.name}}
 {% endfor %}
+{% endif %}
+{% if not forloop.last %}
+---
 {% endif %}
 {% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         'cached-property',
         'celery',
         'django>=1.8,<1.9',
-        'jinja2',
         'markdown2',
         'requests',
         'six',


### PR DESCRIPTION
* Drop jinja, since fine-grained whitespace control isn't necessary
* Fix section labels and spacing

The comment format clearly needs more attention, but this fixes some errors and simplifies the code a bit.

<img width="271" alt="screen shot 2016-04-04 at 12 08 53 pm" src="https://cloud.githubusercontent.com/assets/1633460/14254525/19c38d96-fa5e-11e5-949f-815e96d8801f.png">
