### PR TITLE
Add basic commenting on CFR changes.

### DIFF
--- a/regulations/static/regulations/js/source/collections/comment-collection.js
+++ b/regulations/static/regulations/js/source/collections/comment-collection.js
@@ -11,9 +11,9 @@ var CommentCollection = Backbone.Collection.extend({
   model: CommentModel,
   localStorage: new Backbone.LocalStorage('eregsnc'),
 
-  filter: function(doc) {
+  filter: function(docId) {
     return _.filter(this.models, function(model) {
-      return model.id.split('-')[0] === doc;
+      return model.get('docId') === docId;
     });
   },
 

--- a/regulations/static/regulations/js/source/views/comment/comment-view.js
+++ b/regulations/static/regulations/js/source/views/comment/comment-view.js
@@ -40,6 +40,8 @@ var CommentView = Backbone.View.extend({
   },
 
   initialize: function(options) {
+    this.options = options;
+
     this.$context = this.$el.find('.comment-context');
     this.$container = this.$el.find('.editor-container');
     this.$input = this.$el.find('input[type="file"]');
@@ -65,9 +67,10 @@ var CommentView = Backbone.View.extend({
     if (this.model) {
       this.stopListening(this.model);
     }
+    var opts = {id: section, label: label, docId: this.docId};
     this.model = blank ?
-      new CommentModel({id: section}) :
-      comments.get(section) || new CommentModel({id: section, label: label});
+      new CommentModel(opts) :
+      comments.get(section) || new CommentModel(opts);
     this.listenTo(this.model, 'destroy', this.setSection.bind(this, section, label, true));
     this.render();
   },

--- a/regulations/static/regulations/js/source/views/main/preamble-view.js
+++ b/regulations/static/regulations/js/source/views/main/preamble-view.js
@@ -87,13 +87,14 @@ var PreambleView = ChildView.extend({
     this.$write = this.$el.find('#preamble-write');
 
     this.currentSectionId = this.$read.closest('section').attr('id');
-    this.docId = this.currentSectionId.split('-')[0];
+    this.docId = this.$read.closest('section').data('doc-id');
 
     this.preambleHeadView = new PreambleHeadView();
 
     this.commentView = new CommentView({
       el: this.$write.find('.comment-wrapper'),
-      section: this.currentSectionId
+      section: this.currentSectionId,
+      docId: this.docId
     });
 
     this.commentIndex = new CommentIndexView({

--- a/regulations/templates/regulations/preamble-partial.html
+++ b/regulations/templates/regulations/preamble-partial.html
@@ -1,7 +1,7 @@
 {% load macros render_nested %}
 
 <section id="content-wrapper" class="preamble-wrapper" data-page-type="preamble-section">
-  <section id="{{sub_context.node.label_id}}">
+  <section id="{{sub_context.node.label_id}}" data-doc-id="{{doc_number}}">
     <ul id="preamble-read">
       {% render_nested template=sub_template context=sub_context %}
     </ul>

--- a/regulations/views/preamble.py
+++ b/regulations/views/preamble.py
@@ -104,9 +104,18 @@ class CFRChangesView(View):
         else:
             context = self.regtext_changes_context(amendments, versions,
                                                    label_id=section)
-        return TemplateResponse(
-            request=request, template='regulations/cfr_changes.html',
-            context=context)
+
+        context['use_comments'] = True
+
+        context = {'sub_context': context, 'sub_template': 'regulations/cfr_changes.html',  # noqa
+                   'preamble': None, 'doc_number': doc_number}
+
+        if not request.is_ajax() and request.GET.get('partial') != 'true':
+            template = 'regulations/preamble-chrome.html'
+        else:
+            template = 'regulations/preamble-partial.html'
+        return TemplateResponse(request=request, template=template,
+                                context=context)
 
     @staticmethod
     def authorities_context(amendments, cfr_part):


### PR DESCRIPTION
Very basic, but working. This patch makes an assumption that might turn out to be false, which is that we want to use the same base preamble views (django and backbone) for cfr changes. Paging @cmc333333.

<img width="951" alt="screen shot 2016-04-04 at 8 27 00 pm" src="https://cloud.githubusercontent.com/assets/1633460/14267975/c6ba2a1a-faa3-11e5-8167-7a2c2d84b29c.png">

<img width="1012" alt="screen shot 2016-04-04 at 8 27 34 pm" src="https://cloud.githubusercontent.com/assets/1633460/14267976/cc6e9e64-faa3-11e5-9a7b-e2c1fdf9abec.png">
